### PR TITLE
Don't push images to DockerHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
             only: /.*/
     - prometheus/publish_master:
         context: org-context
-        docker_hub_organization: prometheuscommunity
+        docker_hub_organization: ""  # Don't publish to DockerHub.
         quay_io_organization: prometheuscommunity
         requires:
         - test
@@ -48,7 +48,7 @@ workflows:
             only: master
     - prometheus/publish_release:
         context: org-context
-        docker_hub_organization: prometheuscommunity
+        docker_hub_organization: ""  # Don't publish to DockerHub.
         quay_io_organization: prometheuscommunity
         requires:
         - test


### PR DESCRIPTION
DockerHub announced that as of Nov 1 2020, the number of downloads for
unauthenticated users will be limited. quay.io has no such restrictions
(for now) and there's little incentive for us to host the container
images on 2 platforms.

Closes #41