### PR TITLE
Fix container image name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include Makefile.common
 
 STATICCHECK_IGNORE =
 
-DOCKER_IMAGE_NAME ?= bind-exporter
+DOCKER_IMAGE_NAME ?= prom-label-proxy
 
 .PHONY: run-curl-container
 run-curl-container:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Docker Repository on Quay](https://quay.io/repository/prometheuscommunity/prom-label-proxy/status "Docker Repository on Quay")](https://quay.io/repository/prometheuscommunity/prom-label-proxy)
+
 # prom-label-proxy
 
 The prom-label-proxy can enforce a given label in a given PromQL query, in Prometheus API responses or in Alertmanager API requests.


### PR DESCRIPTION
We accidentally pushed our image to https://quay.io/repository/prometheuscommunity/bind-exporter :disappointed: 