### PR TITLE
.circleci/config.yml: don't use org context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ workflows:
           tags:
             only: /.*/
     - prometheus/publish_master:
-        context: org-context
         docker_hub_organization: ""  # Don't publish to DockerHub.
         quay_io_organization: prometheuscommunity
         requires:
@@ -47,7 +46,6 @@ workflows:
           branches:
             only: master
     - prometheus/publish_release:
-        context: org-context
         docker_hub_organization: ""  # Don't publish to DockerHub.
         quay_io_organization: prometheuscommunity
         requires:


### PR DESCRIPTION
Environment variables defined in the organization's context take
[precedence](https://circleci.com/docs/2.0/env-vars/#order-of-precedence) over variables defined in the project. We use Quay
credentials (QUAY_LOGIN/QUAY_PASSWORD) that are scoped to the project
so we shouldn't pull the variables from the context.