### PR TITLE
Add option to get label value from an HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ Particularly, you can run `prom-label-proxy` with label `tenant` and point to ex
 ```
 prom-label-proxy \
    -label tenant \
+   -query-param tenant \
    -upstream http://demo.do.prometheus.io:9090 \
    -insecure-listen-address 127.0.0.1:8080
 ```
 
-You may, optionally, get the label value from an HTTP header by using the -header parameter:
+You may either get the label value from an HTTP header or from a query-parameter by using -query-param or -header respectively.
 
 ```
 prom-label-proxy \
@@ -58,6 +59,8 @@ prom-label-proxy \
    -upstream http://demo.do.prometheus.io:9090 \
    -insecure-listen-address 127.0.0.1:8080
 ```
+
+If you specify both -query-param and -header, prom-label-proxy will first try to read the query-parameter, and then the header if the query-parameter is not set.
 
 Accessing demo Prometheus APIs on `127.0.0.1:8080` will now expect `tenant` query parameter to be set in the URL:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ prom-label-proxy \
    -insecure-listen-address 127.0.0.1:8080
 ```
 
+You may, optionally, get the label value from an HTTP header by using the -header parameter:
+
+```
+prom-label-proxy \
+   -label tenant \
+   -header X-Scope-OrgID \
+   -upstream http://demo.do.prometheus.io:9090 \
+   -insecure-listen-address 127.0.0.1:8080
+```
+
 Accessing demo Prometheus APIs on `127.0.0.1:8080` will now expect `tenant` query parameter to be set in the URL:
 
 ```bash

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -40,7 +40,7 @@ func NewRoutes(upstream *url.URL, label string, header string) *routes {
 		upstream: upstream,
 		handler:  proxy,
 		label:    label,
-		header:  header,
+		header:   header,
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/federate", enforceMethods(r.federate, "GET"))

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -108,6 +108,7 @@ func (m *mockUpstream) Close() {
 }
 
 const proxyLabel = "namespace"
+const proxyLabelParam = "ns"
 const proxyHeader = "X-Scope-OrgId"
 
 func TestEndpointNotImplemented(t *testing.T) {
@@ -115,10 +116,10 @@ func TestEndpointNotImplemented(t *testing.T) {
 		w.Write(okResponse)
 	}))
 	defer m.Close()
-	r := NewRoutes(m.url, proxyLabel, proxyHeader)
+	r := NewRoutes(m.url, proxyLabel, proxyLabelParam, proxyHeader)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "http://prometheus.example.com/graph?namespace=ns1", nil)
+	req := httptest.NewRequest("GET", "http://prometheus.example.com/graph?ns=ns1", nil)
 
 	r.ServeHTTP(w, req)
 	resp := w.Result()
@@ -185,7 +186,7 @@ func TestMatch(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				r := NewRoutes(m.url, proxyLabel, proxyHeader, WithEnabledLabelsAPI())
+				r := NewRoutes(m.url, proxyLabel, proxyLabelParam, proxyHeader, WithEnabledLabelsAPI())
 
 				u, err := url.Parse(u)
 				if err != nil {
@@ -195,7 +196,7 @@ func TestMatch(t *testing.T) {
 				for _, m := range tc.matches {
 					q.Add(matchersParam, m)
 				}
-				q.Set(proxyLabel, tc.labelv)
+				q.Set(proxyLabelParam, tc.labelv)
 				u.RawQuery = q.Encode()
 
 				w := httptest.NewRecorder()
@@ -380,7 +381,7 @@ func TestQuery(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				r := NewRoutes(m.url, proxyLabel, proxyHeader)
+				r := NewRoutes(m.url, proxyLabel, proxyLabelParam, proxyHeader)
 
 				u, err := url.Parse("http://prometheus.example.com/api/v1/" + endpoint)
 				if err != nil {
@@ -388,7 +389,7 @@ func TestQuery(t *testing.T) {
 				}
 				q := u.Query()
 				q.Set(queryParam, tc.promQuery)
-				q.Set(proxyLabel, tc.labelv)
+				q.Set(proxyLabelParam, tc.labelv)
 				u.RawQuery = q.Encode()
 
 				var b io.Reader = nil
@@ -473,7 +474,7 @@ func TestHeader(t *testing.T) {
 				),
 			)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel, proxyHeader)
+			r := NewRoutes(m.url, proxyLabel, proxyLabelParam, proxyHeader)
 
 			u, err := url.Parse("http://prometheus.example.com/api/v1/query")
 			if err != nil {
@@ -481,7 +482,7 @@ func TestHeader(t *testing.T) {
 			}
 			q := u.Query()
 			q.Set(queryParam, tc.promQuery)
-			q.Set(proxyLabel, tc.labelv)
+			q.Set(proxyLabelParam, tc.labelv)
 			u.RawQuery = q.Encode()
 
 			w := httptest.NewRecorder()

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -440,7 +440,7 @@ func TestHeader(t *testing.T) {
 		{
 			// Query with only query
 			labelv:       "default",
-			headerv:      "defaulth",
+			headerv:      "",
 			promQuery:    "up",
 			expCode:      http.StatusOK,
 			expPromQuery: `up{namespace="default"}`,

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -469,7 +469,7 @@ func TestHeader(t *testing.T) {
 			m := newMockUpstream(
 				checkParameterAbsent(
 					proxyLabel,
-					checkQueryParameterHandler("query", tc.expPromQuery),
+					checkQueryHandler("query", tc.expPromQuery),
 				),
 			)
 			defer m.Close()

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -102,7 +102,7 @@ func TestEndpointNotImplemented(t *testing.T) {
 		w.Write(okResponse)
 	}))
 	defer m.Close()
-	r := NewRoutes(m.url, proxyLabel)
+	r := NewRoutes(m.url, proxyLabel, "")
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "http://prometheus.example.com/graph?namespace=ns1", nil)
@@ -151,7 +151,7 @@ func TestFederate(t *testing.T) {
 				),
 			)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel)
+			r := NewRoutes(m.url, proxyLabel, "")
 
 			u, err := url.Parse("http://prometheus.example.com/federate")
 			if err != nil {
@@ -262,7 +262,7 @@ func TestQuery(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				r := NewRoutes(m.url, proxyLabel)
+				r := NewRoutes(m.url, proxyLabel, "")
 
 				u, err := url.Parse("http://prometheus.example.com/api/v1/" + endpoint)
 				if err != nil {

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -469,7 +469,7 @@ func TestHeader(t *testing.T) {
 			m := newMockUpstream(
 				checkParameterAbsent(
 					proxyLabel,
-					checkQueryHandler("query", tc.expPromQuery),
+					checkQueryHandler("", queryParam, tc.expPromQuery),
 				),
 			)
 			defer m.Close()
@@ -480,7 +480,7 @@ func TestHeader(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			q := u.Query()
-			q.Set("query", tc.promQuery)
+			q.Set(queryParam, tc.promQuery)
 			q.Set(proxyLabel, tc.labelv)
 			u.RawQuery = q.Encode()
 

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -338,7 +338,7 @@ func TestRules(t *testing.T) {
 		{
 			// No "namespace" parameter returns an error.
 			expCode: http.StatusBadRequest,
-			expBody: []byte("Bad request. The \"namespace\" query parameter must be provided.\n"),
+			expBody: []byte("Bad request. The \"ns\" query parameter must be provided.\n"),
 		},
 		{
 			// non 200 status code from upstream is passed as-is.
@@ -658,14 +658,14 @@ func TestRules(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel, "")
+			r := NewRoutes(m.url, proxyLabel, proxyLabelParam, "")
 
 			u, err := url.Parse("http://prometheus.example.com/api/v1/rules")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			q := u.Query()
-			q.Set(proxyLabel, tc.labelv)
+			q.Set(proxyLabelParam, tc.labelv)
 			u.RawQuery = q.Encode()
 
 			w := httptest.NewRecorder()
@@ -716,7 +716,7 @@ func TestAlerts(t *testing.T) {
 		{
 			// No "namespace" parameter returns an error.
 			expCode: http.StatusBadRequest,
-			expBody: []byte("Bad request. The \"namespace\" query parameter must be provided.\n"),
+			expBody: []byte("Bad request. The \"ns\" query parameter must be provided.\n"),
 		},
 		{
 			// non 200 status code from upstream is passed as-is.
@@ -834,14 +834,14 @@ func TestAlerts(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel, "")
+			r := NewRoutes(m.url, proxyLabel, proxyLabelParam, "")
 
 			u, err := url.Parse("http://prometheus.example.com/api/v1/alerts")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			q := u.Query()
-			q.Set(proxyLabel, tc.labelv)
+			q.Set(proxyLabelParam, tc.labelv)
 			u.RawQuery = q.Encode()
 
 			w := httptest.NewRecorder()

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -658,7 +658,7 @@ func TestRules(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel)
+			r := NewRoutes(m.url, proxyLabel, "")
 
 			u, err := url.Parse("http://prometheus.example.com/api/v1/rules")
 			if err != nil {
@@ -834,7 +834,7 @@ func TestAlerts(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel)
+			r := NewRoutes(m.url, proxyLabel, "")
 
 			u, err := url.Parse("http://prometheus.example.com/api/v1/alerts")
 			if err != nil {

--- a/injectproxy/silences.go
+++ b/injectproxy/silences.go
@@ -66,7 +66,7 @@ func (r *routes) listSilences(w http.ResponseWriter, req *http.Request) {
 	}
 
 	q["filter"] = modified
-	q.Del(r.label)
+	q.Del(r.labelParam)
 	req.URL.RawQuery = q.Encode()
 
 	r.handler.ServeHTTP(w, req)

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -73,7 +73,7 @@ func TestListSilences(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryParameterHandler("filter", tc.expFilters...))
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel)
+			r := NewRoutes(m.url, proxyLabel, "")
 
 			u, err := url.Parse("http://alertmanager.example.com/api/v2/silences")
 			if err != nil {
@@ -297,7 +297,7 @@ func TestDeleteSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel)
+			r := NewRoutes(m.url, proxyLabel, "")
 
 			u, err := url.Parse(fmt.Sprintf("http://alertmanager.example.com/api/v2/silence/" + tc.ID))
 			if err != nil {
@@ -489,7 +489,7 @@ func TestUpdateSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel)
+			r := NewRoutes(m.url, proxyLabel, "")
 
 			u, err := url.Parse("http://alertmanager.example.com/api/v2/silences/")
 			if err != nil {

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -73,7 +73,7 @@ func TestListSilences(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", "filter", tc.expFilters...))
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel, "")
+			r := NewRoutes(m.url, proxyLabel, proxyLabelParam, "")
 
 			u, err := url.Parse("http://alertmanager.example.com/api/v2/silences")
 			if err != nil {
@@ -83,7 +83,7 @@ func TestListSilences(t *testing.T) {
 			for _, m := range tc.filters {
 				q.Add("filter", m)
 			}
-			q.Set(proxyLabel, tc.labelv)
+			q.Set(proxyLabelParam, tc.labelv)
 			u.RawQuery = q.Encode()
 
 			w := httptest.NewRecorder()
@@ -297,14 +297,14 @@ func TestDeleteSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel, "")
+			r := NewRoutes(m.url, proxyLabel, proxyLabelParam, "")
 
 			u, err := url.Parse(fmt.Sprintf("http://alertmanager.example.com/api/v2/silence/" + tc.ID))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			q := u.Query()
-			q.Set(proxyLabel, tc.labelv)
+			q.Set(proxyLabelParam, tc.labelv)
 			u.RawQuery = q.Encode()
 
 			w := httptest.NewRecorder()
@@ -489,14 +489,14 @@ func TestUpdateSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r := NewRoutes(m.url, proxyLabel, "")
+			r := NewRoutes(m.url, proxyLabel, proxyLabelParam, "")
 
 			u, err := url.Parse("http://alertmanager.example.com/api/v2/silences/")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			q := u.Query()
-			q.Set(proxyLabel, tc.labelv)
+			q.Set(proxyLabelParam, tc.labelv)
 			u.RawQuery = q.Encode()
 
 			w := httptest.NewRecorder()

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	flagset.StringVar(&upstream, "upstream", "", "The upstream URL to proxy to.")
 	flagset.StringVar(&label, "label", "", "The label to enforce in all proxied PromQL queries.")
 	flagset.StringVar(&labelParam, "query-param", "", "The HTTP query parameter from which to get the label.")
-	flagset.StringVar(&header, "header", "", "(Optional) An HTTP header to get the label value from.")
+	flagset.StringVar(&header, "header", "", "The HTTP header to get the label value from.")
 	flagset.BoolVar(&enableLabelAPIs, "enable-label-apis", false, "When specified proxy allows to inject label to label APIs like /api/v1/labels and /api/v1/label/<name>/values."+
 		"NOTE: Enable with care. Selection of matcher is still in development, see https://github.com/thanos-io/thanos/issues/3351 and https://github.com/prometheus/prometheus/issues/6178. If enabled and"+
 		"any labels endpoint does not support selectors, injected matcher will be silently dropped.")
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	if labelParam == "" && header == "" {
-		log.Fatalf("at least one of -query-param and -header must be given")
+		log.Fatalf("at least one of -query-param or -header must be given")
 	}
 
 	upstreamURL, err := url.Parse(upstream)

--- a/main.go
+++ b/main.go
@@ -31,12 +31,14 @@ func main() {
 		insecureListenAddress string
 		upstream              string
 		label                 string
+		header                string
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flagset.StringVar(&insecureListenAddress, "insecure-listen-address", "", "The address the prom-label-proxy HTTP server should listen on.")
 	flagset.StringVar(&upstream, "upstream", "", "The upstream URL to proxy to.")
 	flagset.StringVar(&label, "label", "", "The label to enforce in all proxied PromQL queries.")
+	flagset.StringVar(&header, "header", "", "(Optional) An HTTP header to get the label value from.")
 	//nolint: errcheck // Parse() will exit on error.
 	flagset.Parse(os.Args[1:])
 	if label == "" {
@@ -52,7 +54,7 @@ func main() {
 		log.Fatalf("Invalid scheme for upstream URL %q, only 'http' and 'https' are supported", upstream)
 	}
 
-	routes := injectproxy.NewRoutes(upstreamURL, label)
+	routes := injectproxy.NewRoutes(upstreamURL, label, header)
 	mux := http.NewServeMux()
 	mux.Handle("/", routes)
 


### PR DESCRIPTION
This PR allows the client to send the label value as an HTTP header. Doing it this way, combined with #53 will allow this to be used for alerting in Grafana.