### PR TITLE
Add option to get label value from an HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,22 @@ Particularly, you can run `prom-label-proxy` with label `tenant` and point to ex
 ```
 prom-label-proxy \
    -label tenant \
+   -query-param tenant \
    -upstream http://demo.do.prometheus.io:9090 \
    -insecure-listen-address 127.0.0.1:8080
 ```
+
+You may either get the label value from an HTTP header or from a query-parameter by using -query-param or -header respectively.
+
+```
+prom-label-proxy \
+   -label tenant \
+   -header X-Scope-OrgID \
+   -upstream http://demo.do.prometheus.io:9090 \
+   -insecure-listen-address 127.0.0.1:8080
+```
+
+If you specify both -query-param and -header, prom-label-proxy will first try to read the query-parameter, and then the header if the query-parameter is not set.
 
 Accessing demo Prometheus APIs on `127.0.0.1:8080` will now expect `tenant` query parameter to be set in the URL:
 

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -34,9 +34,11 @@ const (
 )
 
 type routes struct {
-	upstream *url.URL
-	handler  http.Handler
-	label    string
+	upstream   *url.URL
+	handler    http.Handler
+	label      string
+	queryParam string
+	header     string
 
 	mux            *http.ServeMux
 	modifiers      map[string]func(*http.Response) error
@@ -47,6 +49,8 @@ type options struct {
 	enableLabelAPIs  bool
 	passthroughPaths []string
 	errorOnReplace   bool
+	queryParam      string
+	headerName      string
 }
 
 type Option interface {
@@ -63,6 +67,22 @@ func (f optionFunc) apply(o *options) {
 func WithEnabledLabelsAPI() Option {
 	return optionFunc(func(o *options) {
 		o.enableLabelAPIs = true
+	})
+}
+
+// WithValueFromQuery fetches the label value from the query parameters
+func WithValueFromQuery(paramName string) Option {
+	return optionFunc(func(o *options) {
+		o.queryParam = paramName
+		o.headerName = ""
+	})
+}
+
+// WithValueFromHeader fetches the label value from an HTTP header
+func WithValueFromHeader(headerName string) Option {
+	return optionFunc(func(o *options) {
+		o.headerName = headerName
+		o.queryParam = ""
 	})
 }
 
@@ -132,9 +152,21 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 		o.apply(&opt)
 	}
 
+	if opt.queryParam == "" && opt.headerName == "" {
+		// fallback to old behaviour
+		opt.queryParam = label
+	}
+
 	proxy := httputil.NewSingleHostReverseProxy(upstream)
 
-	r := &routes{upstream: upstream, handler: proxy, label: label, errorOnReplace: opt.errorOnReplace}
+	r := &routes{
+		upstream:       upstream,
+		handler:        proxy,
+		label:          label,
+		errorOnReplace: opt.errorOnReplace,
+		queryParam:     opt.queryParam,
+		header:         opt.headerName,
+	}
 	mux := newStrictMux()
 
 	errs := merrors.New(
@@ -198,10 +230,19 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 
 func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		lvalue := req.FormValue(r.label)
-		if lvalue == "" {
-			http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
-			return
+		var lvalue string
+		if r.queryParam != "" {
+			lvalue = req.FormValue(r.queryParam)
+			if lvalue == "" {
+				http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.queryParam), http.StatusBadRequest)
+				return
+			}
+		} else {
+			lvalue = req.Header.Get(r.header)
+			if lvalue == "" {
+				http.Error(w, fmt.Sprintf("Bad request. The Header %q must be provided.", r.header), http.StatusBadRequest)
+				return
+			}
 		}
 		req = req.WithContext(withLabelValue(req.Context(), lvalue))
 
@@ -271,8 +312,8 @@ func mustLabelValue(ctx context.Context) string {
 	return label
 }
 
-func withLabelValue(ctx context.Context, label string) context.Context {
-	return context.WithValue(ctx, keyLabel, label)
+func withLabelValue(ctx context.Context, lvalue string) context.Context {
+	return context.WithValue(ctx, keyLabel, lvalue)
 }
 
 func (r *routes) passthrough(w http.ResponseWriter, req *http.Request) {

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -901,3 +901,173 @@ func TestQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestUsingCustomQueryParameter(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		labelv        string
+		promQuery     string
+		promQueryBody string
+		method        string
+
+		expCode          int
+		expPromQuery     string
+		expPromQueryBody string
+		expResponse      []byte
+	}{
+		{
+			name:    `No "foobar" parameter returns an error`,
+			expCode: http.StatusBadRequest,
+		},
+		{
+			name:         `Query without a vector selector`,
+			labelv:       "default",
+			promQuery:    "up",
+			expCode:      http.StatusOK,
+			expPromQuery: `up{namespace="default"}`,
+			expResponse:  okResponse,
+		},
+	} {
+		for _, endpoint := range []string{"query", "query_range"} {
+			t.Run(endpoint+"/"+strings.ReplaceAll(tc.name, " ", "_"), func(t *testing.T) {
+				var expBody string
+				if tc.expPromQueryBody != "" {
+					expBody = url.Values(map[string][]string{"query": {tc.expPromQueryBody}}).Encode()
+				}
+				m := newMockUpstream(
+					checkParameterAbsent(
+						proxyLabel,
+						checkQueryHandler(expBody, queryParam, tc.expPromQuery),
+					),
+				)
+				defer m.Close()
+				r, err := NewRoutes(m.url, proxyLabel, WithValueFromQuery("foobar"))
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				u, err := url.Parse("http://prometheus.example.com/api/v1/" + endpoint)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				q := u.Query()
+				q.Set(queryParam, tc.promQuery)
+				q.Set("foobar", tc.labelv)
+				u.RawQuery = q.Encode()
+
+				var b io.Reader = nil
+				if tc.promQueryBody != "" {
+					b = strings.NewReader(url.Values(map[string][]string{"query": {tc.promQueryBody}}).Encode())
+				}
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(tc.method, u.String(), b)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				r.ServeHTTP(w, req)
+
+				resp := w.Result()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode != tc.expCode {
+					t.Logf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
+					t.Logf("%s", string(body))
+					t.FailNow()
+				}
+				if resp.StatusCode != http.StatusOK {
+					return
+				}
+				if string(body) != string(tc.expResponse) {
+					t.Fatalf("expected response body %q, got %q", string(tc.expResponse), string(body))
+				}
+			})
+		}
+	}
+}
+
+func TestUsingCustomHTTPHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		labelv        string
+		promQuery     string
+		promQueryBody string
+		method        string
+
+		expCode          int
+		expPromQuery     string
+		expPromQueryBody string
+		expResponse      []byte
+	}{
+		{
+			name:    `No "X-Namespace" header returns an error`,
+			expCode: http.StatusBadRequest,
+		},
+		{
+			name:         `Query without a vector selector`,
+			labelv:       "default",
+			promQuery:    "up",
+			expCode:      http.StatusOK,
+			expPromQuery: `up{namespace="default"}`,
+			expResponse:  okResponse,
+		},
+	} {
+		for _, endpoint := range []string{"query", "query_range"} {
+			t.Run(endpoint+"/"+strings.ReplaceAll(tc.name, " ", "_"), func(t *testing.T) {
+				var expBody string
+				if tc.expPromQueryBody != "" {
+					expBody = url.Values(map[string][]string{"query": {tc.expPromQueryBody}}).Encode()
+				}
+				m := newMockUpstream(
+					checkParameterAbsent(
+						proxyLabel,
+						checkQueryHandler(expBody, queryParam, tc.expPromQuery),
+					),
+				)
+				defer m.Close()
+				r, err := NewRoutes(m.url, proxyLabel, WithValueFromHeader("x-namespace"))
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				u, err := url.Parse("http://prometheus.example.com/api/v1/" + endpoint)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				q := u.Query()
+				q.Set(queryParam, tc.promQuery)
+				u.RawQuery = q.Encode()
+
+				var b io.Reader = nil
+				if tc.promQueryBody != "" {
+					b = strings.NewReader(url.Values(map[string][]string{"query": {tc.promQueryBody}}).Encode())
+				}
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest(tc.method, u.String(), b)
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				req.Header.Set("X-Namespace", tc.labelv)
+				r.ServeHTTP(w, req)
+
+				resp := w.Result()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				defer resp.Body.Close()
+
+				if resp.StatusCode != tc.expCode {
+					t.Logf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
+					t.Logf("%s", string(body))
+					t.FailNow()
+				}
+				if resp.StatusCode != http.StatusOK {
+					return
+				}
+				if string(body) != string(tc.expResponse) {
+					t.Fatalf("expected response body %q, got %q", string(tc.expResponse), string(body))
+				}
+			})
+		}
+	}
+}

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -658,7 +658,7 @@ func TestRules(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel)
+			r, err := NewRoutes(m.url, proxyLabel, WithValueFromQuery(proxyLabel))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/silences.go
+++ b/injectproxy/silences.go
@@ -66,7 +66,7 @@ func (r *routes) enforceFilterParameter(w http.ResponseWriter, req *http.Request
 	}
 
 	q["filter"] = modified
-	q.Del(r.label)
+	q.Del(r.queryParam)
 	req.URL.RawQuery = q.Encode()
 
 	r.handler.ServeHTTP(w, req)

--- a/main.go
+++ b/main.go
@@ -32,14 +32,19 @@ func main() {
 		insecureListenAddress  string
 		upstream               string
 		label                  string
+		headerName             string
+		queryParam             string
 		enableLabelAPIs        bool
 		unsafePassthroughPaths string // Comma-delimited string.
 		errorOnReplace         bool
+		header                 string
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flagset.StringVar(&insecureListenAddress, "insecure-listen-address", "", "The address the prom-label-proxy HTTP server should listen on.")
 	flagset.StringVar(&upstream, "upstream", "", "The upstream URL to proxy to.")
+	flagset.StringVar(&queryParam, "query-param", "", "The query parameter to obtain the label value from. This or -header is required.")
+	flagset.StringVar(&headerName, "header", "", "The HTTP header name to obtain the label value from. This or -query-param is required.")
 	flagset.StringVar(&label, "label", "", "The label to enforce in all proxied PromQL queries. "+
 		"This label will be also required as the URL parameter to get the value to be injected. For example: -label=tenant will"+
 		" make it required for this proxy to have URL in form of: <URL>?tenant=abc&other_params...")
@@ -57,6 +62,18 @@ func main() {
 		log.Fatalf("-label flag cannot be empty")
 	}
 
+	var opts []injectproxy.Option
+
+	if (queryParam != "" && header != "") || (queryParam == "" && header == "") {
+		log.Fatal("exactly one of -query-param and -header must be given")
+	}
+	if queryParam != "" {
+		opts = append(opts, injectproxy.WithValueFromQuery(queryParam))
+	}
+	if header != "" {
+		opts = append(opts, injectproxy.WithValueFromHeader(header))
+	}
+
 	upstreamURL, err := url.Parse(upstream)
 	if err != nil {
 		log.Fatalf("Failed to build parse upstream URL: %v", err)
@@ -66,7 +83,6 @@ func main() {
 		log.Fatalf("Invalid scheme for upstream URL %q, only 'http' and 'https' are supported", upstream)
 	}
 
-	var opts []injectproxy.Option
 	if enableLabelAPIs {
 		opts = append(opts, injectproxy.WithEnabledLabelsAPI())
 	}


### PR DESCRIPTION
This allows to use the proxy in settings where query parameters
cannot be used; this could be behind specific reverse proxies, or
when HTTP POST is required (see #53).

This work is heavily based on the work done by
Andreas Plesner <apj@mutt.dk> in [1]. I (Jonas Schäfer) ported
this to the current head of master.

   [1]: https://github.com/prometheus-community/prom-label-proxy/pull/54

This is a rebase of #54. Please review carefully. I only ran the test suite so far.