### PR TITLE
Proxy exemplars API

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -134,6 +134,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 		mux.Handle("/api/v1/alerts", r.enforceLabel(enforceMethods(r.passthrough, "GET"))),
 		mux.Handle("/api/v1/rules", r.enforceLabel(enforceMethods(r.passthrough, "GET"))),
 		mux.Handle("/api/v1/series", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
+		mux.Handle("/api/v1/query_exemplars", r.enforceLabel(enforceMethods(r.query, "GET", "POST"))),
 	)
 
 	if opt.enableLabelAPIs {

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -455,8 +455,16 @@ func TestQuery(t *testing.T) {
 			method:        http.MethodPost,
 			expCode:       http.StatusOK,
 		},
+		{
+			name:         `Binary expression`,
+			labelv:       "default",
+			promQuery:    `up{instance="localhost:9090"} + foo{namespace="other"}`,
+			expCode:      http.StatusOK,
+			expPromQuery: `up{instance="localhost:9090",namespace="default"} + foo{namespace="default"}`,
+			expResponse:  okResponse,
+		},
 	} {
-		for _, endpoint := range []string{"query", "query_range"} {
+		for _, endpoint := range []string{"query", "query_range", "query_exemplars"} {
 			t.Run(endpoint+"/"+strings.ReplaceAll(tc.name, " ", "_"), func(t *testing.T) {
 				var expBody string
 				if tc.expPromQueryBody != "" {


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

This pr adds the label enforce support for the new `query_exemplars` API.