### PR TITLE
return error if existing label matcher in query would change

### DIFF
--- a/injectproxy/enforce.go
+++ b/injectproxy/enforce.go
@@ -39,7 +39,7 @@ func NewEnforcer(errorOnReplace bool, ms ...*labels.Matcher) *Enforcer {
 	}
 }
 
-var ErrIllegalLabelMatcher = errors.New("Label matcher value conflicts with injected value")
+var ErrIllegalLabelMatcher = errors.New("label matcher value conflicts with injected value")
 
 // EnforceNode walks the given node recursively
 // and enforces the given label enforcer on it.

--- a/injectproxy/enforce_test.go
+++ b/injectproxy/enforce_test.go
@@ -54,6 +54,15 @@ func hasError(want error) checkFunc {
 	}
 }
 
+func hasIllegalLabelMatcherError() checkFunc {
+	return func(_ string, got error) error {
+		if _, ok := got.(IllegalLabelMatcherError); ok {
+			return nil
+		}
+		return fmt.Errorf("want error of type IllegalLabelMatcherError, got %v", got)
+	}
+}
+
 func hasExpression(want string) checkFunc {
 	return func(got string, _ error) error {
 		if want != got {
@@ -176,7 +185,7 @@ var tests = []struct {
 			},
 		),
 		check: checks(
-			hasError(ErrIllegalLabelMatcher),
+			hasIllegalLabelMatcherError(),
 		),
 	},
 
@@ -197,7 +206,7 @@ var tests = []struct {
 			},
 		),
 		check: checks(
-			hasError(ErrIllegalLabelMatcher),
+			hasIllegalLabelMatcherError(),
 		),
 	},
 
@@ -218,7 +227,7 @@ var tests = []struct {
 			},
 		),
 		check: checks(
-			hasError(ErrIllegalLabelMatcher),
+			hasIllegalLabelMatcherError(),
 		),
 	},
 
@@ -239,7 +248,7 @@ var tests = []struct {
 			},
 		),
 		check: checks(
-			hasError(ErrIllegalLabelMatcher),
+			hasIllegalLabelMatcherError(),
 		),
 	},
 	// and lastly check that passing the label matcher we would inject

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -38,13 +38,15 @@ type routes struct {
 	handler  http.Handler
 	label    string
 
-	mux       *http.ServeMux
-	modifiers map[string]func(*http.Response) error
+	mux            *http.ServeMux
+	modifiers      map[string]func(*http.Response) error
+	errorOnReplace bool
 }
 
 type options struct {
 	enableLabelAPIs bool
 	pasthroughPaths []string
+	errorOnReplace  bool
 }
 
 type Option interface {
@@ -70,6 +72,14 @@ func WithEnabledLabelsAPI() Option {
 func WithPassthroughPaths(paths []string) Option {
 	return optionFunc(func(o *options) {
 		o.pasthroughPaths = paths
+	})
+}
+
+// ErrorOnReplace causes the proxy to return 403 if a label matcher we want to
+// inject is present in the query already and matches something different
+func WithErrorOnReplace() Option {
+	return optionFunc(func(o *options) {
+		o.errorOnReplace = true
 	})
 }
 
@@ -124,7 +134,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 
 	proxy := httputil.NewSingleHostReverseProxy(upstream)
 
-	r := &routes{upstream: upstream, handler: proxy, label: label}
+	r := &routes{upstream: upstream, handler: proxy, label: label, errorOnReplace: opt.errorOnReplace}
 	mux := newStrictMux()
 
 	errs := merrors.New(
@@ -251,11 +261,12 @@ func (r *routes) passthrough(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *routes) query(w http.ResponseWriter, req *http.Request) {
-	e := NewEnforcer([]*labels.Matcher{{
-		Name:  r.label,
-		Type:  labels.MatchEqual,
-		Value: mustLabelValue(req.Context()),
-	}}...)
+	e := NewEnforcer(r.errorOnReplace,
+		[]*labels.Matcher{{
+			Name:  r.label,
+			Type:  labels.MatchEqual,
+			Value: mustLabelValue(req.Context()),
+		}}...)
 
 	// The `query` can come in the URL query string and/or the POST body.
 	// For this reason, we need to try to enforcing in both places.
@@ -264,6 +275,9 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	// enforce in both places.
 	q, found1, err := enforceQueryValues(e, req.URL.Query())
 	if err != nil {
+		if err == ErrIllegalLabelMatcher {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 		return
 	}
 	req.URL.RawQuery = q
@@ -276,6 +290,9 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 		}
 		q, found2, err = enforceQueryValues(e, req.PostForm)
 		if err != nil {
+			if err == ErrIllegalLabelMatcher {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			}
 			return
 		}
 		// We are replacing request body, close previous one (ParseForm ensures it is read fully and not nil).

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -275,7 +275,7 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	// enforce in both places.
 	q, found1, err := enforceQueryValues(e, req.URL.Query())
 	if err != nil {
-		if err == ErrIllegalLabelMatcher {
+		if _, ok := err.(IllegalLabelMatcherError); ok {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		return
@@ -290,7 +290,7 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 		}
 		q, found2, err = enforceQueryValues(e, req.PostForm)
 		if err != nil {
-			if err == ErrIllegalLabelMatcher {
+			if _, ok := err.(IllegalLabelMatcherError); ok {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 			}
 			return


### PR DESCRIPTION
Before this commit, if the inject proxy is configured to replace label
foo and a query is encountered that has one or more label matchers for
the foo label, these matchers are silently replaced. E.g. a query like
`up{foo="default"}` would silently be altered to
`up{foo="replacement"}` and the query result returned.
With this change we return 400 instead.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>