### PR TITLE
Fully support POST: enforceLabel/matcher/labelAPI (#55)

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -149,7 +149,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 
 	if opt.enableLabelAPIs {
 		errs.Add(
-			mux.Handle("/api/v1/labels", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
+			mux.Handle("/api/v1/labels", r.enforceLabel(enforceMethods(r.matcher, "GET", "POST"))),
 			// Full path is /api/v1/label/<label_name>/values but http mux does not support patterns.
 			// This is fine though as we don't care about name for matcher injector.
 			mux.Handle("/api/v1/label/", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
@@ -197,7 +197,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 
 func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		lvalue := req.URL.Query().Get(r.label)
+		lvalue := req.FormValue(r.label)
 		if lvalue == "" {
 			http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
 			return
@@ -206,8 +206,23 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 
 		// Remove the proxy label from the query parameters.
 		q := req.URL.Query()
-		q.Del(r.label)
+		if q.Get(r.label) != "" {
+			q.Del(r.label)
+		}
 		req.URL.RawQuery = q.Encode()
+		// Remove the proxy label from the form.
+		if req.Form.Get(r.label) != "" {
+			req.Form.Del(r.label)
+		}
+		// Remove the proxy label from the PostForm.
+		if req.PostForm.Get(r.label) != "" {
+			req.PostForm.Del(r.label)
+			newBody := req.PostForm.Encode()
+			// We are replacing request body, close previous one (req.FormValue ensures it is read fully and not nil).
+			_ = req.Body.Close()
+			req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+			req.ContentLength = int64(len(newBody))
+		}
 
 		h.ServeHTTP(w, req)
 	})
@@ -339,8 +354,7 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 		Type:  labels.MatchEqual,
 		Value: mustLabelValue(req.Context()),
 	}
-
-	q := req.URL.Query()
+	q := req.Form
 	matchers := q[matchersParam]
 	if len(matchers) == 0 {
 		q.Set(matchersParam, matchersToString(matcher))
@@ -356,7 +370,15 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 		q[matchersParam] = matchers
 	}
 
-	req.URL.RawQuery = q.Encode()
+	if req.Method == http.MethodPost {
+		// We are replacing request body, close previous one (ParseForm ensures it is read fully and not nil).
+		_ = req.Body.Close()
+		newBody := q.Encode()
+		req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+		req.ContentLength = int64(len(newBody))
+	} else {
+		req.URL.RawQuery = q.Encode()
+	}
 	r.handler.ServeHTTP(w, req)
 }
 

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -210,10 +210,6 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 			q.Del(r.label)
 		}
 		req.URL.RawQuery = q.Encode()
-		// Remove the proxy label from the form.
-		if req.Form.Get(r.label) != "" {
-			req.Form.Del(r.label)
-		}
 		// Remove the proxy label from the PostForm.
 		if req.PostForm.Get(r.label) != "" {
 			req.PostForm.Del(r.label)

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -102,7 +102,7 @@ func checkFormHandler(key string, values ...string) http.Handler {
 			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
 			return
 		}
-		kvs := req.Form
+		kvs := req.PostForm
 		// Verify that the client provides the parameter only once.
 		if len(kvs[key]) != len(values) {
 			http.Error(w, fmt.Sprintf("expected %d values of parameter %q, got %d", len(values), key, len(kvs[key])), http.StatusInternalServerError)


### PR DESCRIPTION
Closes #55

Grafana always use POST when grafana alert query Prometheus ref: [grafana code](https://github.com/grafana/grafana/blob/main/pkg/tsdb/prometheus/prometheus.go#L89) , [prometheus client_golang code](https://github.com/prometheus/client_golang/blob/master/api/prometheus/v1/api.go#L1101)

Grafana 8.0 default use POST in Prometheus datasource. ref: [grafana#34599](https://github.com/grafana/grafana/pull/34599)

Current, `prom-label-proxy` cannot proxy POST method correctly.  

```
 go run main.go  -label namespace -upstream http://127.0.0.1:9090 -insecure-listen-address :29192 -enable-label-apis -unsafe-passthrough-paths /api/v1/metadata,/api/v1/query_exemplars
```

main/master branch:
![image](https://user-images.githubusercontent.com/7621241/122346949-18914500-cf7c-11eb-8254-b29016fdbac0.png)
![image](https://user-images.githubusercontent.com/7621241/122346977-21821680-cf7c-11eb-9d1d-ea00d6f3beea.png)

this PR fixed it, make `prom-label-proxy` proxy POST method correctly: 
![image](https://user-images.githubusercontent.com/7621241/122347159-52624b80-cf7c-11eb-8c5a-6935d63fc5ae.png)


hi @bwplotka  @s-urbaniak Could you help review? thank you :)
