### PR TITLE
README: add authzed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The prom-label-proxy can enforce a given label in a given PromQL query, in Prometheus API responses or in Alertmanager API requests. As an example (but not only),
 this allows read multi-tenancy for projects like Prometheus, Alertmanager or Thanos.
 
-This proxy does not perform authentication or authorization, this has to happen before the request reaches this proxy, allowing you to use any authN/authZ system you want. The [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) is an example for such an additional building block.
+This proxy does not perform authentication or authorization, this has to happen before the request reaches this proxy, allowing you to use any authN/authZ system you want. The [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) is an example for such an additional building block. Additionally, you can use prom-label-proxy as a library in your own proxy, like what is done in [prom-authzed-proxy](https://github.com/authzed/prom-authzed-proxy).
 
 ### Risks outside the scope of this project:
 


### PR DESCRIPTION
Hey there 👋 

First of all a big thanks to the community for building and maintaining an incredibly useful project.

[We built our own proxy](https://github.com/authzed/prom-authzed-proxy) based on prom-label-proxy that enables our users to query our internal Prometheus stack securely.
I think it'd be useful mention this in the README, because it uses this project as library, rather running it standalone and putting another proxy in front of it.

I'm also open to discussing where we found it difficult/annoying to use this project as a library and how we could improve that experience, if it's something the community is interested in.