### PR TITLE
main.go: fix help text for --unsafe-passthrough-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ go get github.com/prometheus-community/prom-label-proxy
 This application proxies the following endpoints and it ensures that a particular label is enforced in the particular request and response:
 
 * `/federate` for GET method (Prometheus)
-* `/api/v1/query_exemplars` for GET and POST methods (Prometheus)
+* `/api/v1/query_exemplars` for GET and POST methods (Prometheus/Thanos)
 * `/api/v1/query` for GET and POST methods (Prometheus/Thanos)
 * `/api/v1/query_range` for GET and POST methods (Prometheus/Thanos)
 * `/api/v1/series` for GET method (Prometheus/Thanos)
@@ -103,8 +103,9 @@ This is enforced for any case, whether a label matcher is specified in the origi
 
 Similar to query endpoint, for metadata endpoints `/api/v1/series`, `/api/v1/labels`, `/api/v1/label/<name>/values` the proxy injects the specified label all the provided `match[]` selectors.
 
-NOTE: At the moment of creation `/api/v1/labels`, `/api/v1/label/<name>/values` does not support `match[]` so they are disabled by default. Use `-enable-label-apis` flag to enable
-those (see https://github.com/prometheus/prometheus/issues/6178 for tracking development).
+NOTE: When the `/api/v1/labels` and `/api/v1/label/<name>/values` endpoints were added to `prom-label-proxy`, the Prometheus and Thanos endpoints didn't support the `match[]` parameter hence the `prom-label-proxy` labels endpoints are disabled by default. Use the `-enable-label-apis` flag to enable with care. Ensure that the upstream endpoints support label selectors:
+* Prometheus >= [2.24.0](https://github.com/prometheus/prometheus/releases/tag/v2.24.0)
+* Thanos >= [v0.18.0](https://github.com/thanos-io/thanos/releases/tag/v0.18.0) at least, >= [0.23.0](https://github.com/thanos-io/thanos/releases/tag/v0.23.0) recommended for better performances.
 
 ### Rules endpoint
 

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -44,9 +44,9 @@ type routes struct {
 }
 
 type options struct {
-	enableLabelAPIs bool
-	pasthroughPaths []string
-	errorOnReplace  bool
+	enableLabelAPIs  bool
+	passthroughPaths []string
+	errorOnReplace   bool
 }
 
 type Option interface {
@@ -71,7 +71,7 @@ func WithEnabledLabelsAPI() Option {
 // NOTE: Passthrough "all" paths like "/" or "" and regex are not allowed.
 func WithPassthroughPaths(paths []string) Option {
 	return optionFunc(func(o *options) {
-		o.pasthroughPaths = paths
+		o.passthroughPaths = paths
 	})
 }
 
@@ -166,21 +166,21 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 	}
 
 	// Validate paths.
-	for _, path := range opt.pasthroughPaths {
+	for _, path := range opt.passthroughPaths {
 		u, err := url.Parse(fmt.Sprintf("http://example.com%v", path))
 		if err != nil {
-			return nil, fmt.Errorf("path %v is not a valid URI path, got %v", path, opt.pasthroughPaths)
+			return nil, fmt.Errorf("path %q is not a valid URI path, got %v", path, opt.passthroughPaths)
 		}
 		if u.Path != path {
-			return nil, fmt.Errorf("path %v is not a valid URI path, got %v", path, opt.pasthroughPaths)
+			return nil, fmt.Errorf("path %q is not a valid URI path, got %v", path, opt.passthroughPaths)
 		}
 		if u.Path == "" || u.Path == "/" {
-			return nil, fmt.Errorf("path %v is not allowed, got %v", u.Path, opt.pasthroughPaths)
+			return nil, fmt.Errorf("path %q is not allowed, got %v", u.Path, opt.passthroughPaths)
 		}
 	}
 
 	// Register optional passthrough paths.
-	for _, path := range opt.pasthroughPaths {
+	for _, path := range opt.passthroughPaths {
 		if err := mux.Handle(path, http.HandlerFunc(r.passthrough)); err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -43,12 +43,12 @@ func main() {
 	flagset.StringVar(&label, "label", "", "The label to enforce in all proxied PromQL queries. "+
 		"This label will be also required as the URL parameter to get the value to be injected. For example: -label=tenant will"+
 		" make it required for this proxy to have URL in form of: <URL>?tenant=abc&other_params...")
-	flagset.BoolVar(&enableLabelAPIs, "enable-label-apis", false, "When specified proxy allows to inject label to label APIs like /api/v1/labels and /api/v1/label/<name>/values."+
-		"NOTE: Enable with care. Selection of matcher is still in development, see https://github.com/thanos-io/thanos/issues/3351 and https://github.com/prometheus/prometheus/issues/6178. If enabled and"+
-		"any labels endpoint does not support selectors, injected matcher will be silently dropped.")
-	flagset.StringVar(&unsafePassthroughPaths, "unsafe-passthrough-paths", "", "Comma delimited allow list of exact HTTP path segments should be allowed to hit upstream URL without any enforcement."+
-		"This option is checked after Prometheus APIs, you can cannot override enforced API to be not enforced with this option. Use carefully as it can easily cause a data leak if the provided path is an important"+
-		"API like targets or configuration. NOTE: \"all\" matching paths like \"/\" or \"\" and regex are not allowed.")
+	flagset.BoolVar(&enableLabelAPIs, "enable-label-apis", false, "When specified proxy allows to inject label to label APIs like /api/v1/labels and /api/v1/label/<name>/values. "+
+		"NOTE: Enable with care because filtering by matcher is not implemented in older versions of Prometheus (>= v2.24.0 required) and Thanos (>= v0.18.0 required, >= v0.23.0 recommended). If enabled and "+
+		"any labels endpoint does not support selectors, the injected matcher will have no effect.")
+	flagset.StringVar(&unsafePassthroughPaths, "unsafe-passthrough-paths", "", "Comma delimited allow list of exact HTTP path segments that should be allowed to hit upstream URL without any enforcement. "+
+		"This option is checked after Prometheus APIs, you cannot override enforced API endpoints to be not enforced with this option. Use carefully as it can easily cause a data leak if the provided path is an important "+
+		"API (like /api/v1/configuration) which isn't enforced by prom-label-proxy. NOTE: \"all\" matching paths like \"/\" or \"\" and regex are not allowed.")
 	flagset.BoolVar(&errorOnReplace, "error-on-replace", false, "When specified, the proxy will return HTTP status code 400 if the query already contains a label matcher that differs from the one the proxy would inject.")
 
 	//nolint: errcheck // Parse() will exit on error.


### PR DESCRIPTION
Signed-off-by: Simon Pasquier <spasquie@redhat.com>