### PR TITLE
always parse request post form

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -211,17 +211,19 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 		}
 		req.URL.RawQuery = q.Encode()
 		// Remove the proxy label from the PostForm.
-		if err := req.ParseForm(); err != nil {
-			http.Error(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
-			return
-		}
-		if req.PostForm.Get(r.label) != "" {
-			req.PostForm.Del(r.label)
-			newBody := req.PostForm.Encode()
-			// We are replacing request body, close previous one (req.FormValue ensures it is read fully and not nil).
-			_ = req.Body.Close()
-			req.Body = ioutil.NopCloser(strings.NewReader(newBody))
-			req.ContentLength = int64(len(newBody))
+		if req.Method == http.MethodPost {
+			if err := req.ParseForm(); err != nil {
+				http.Error(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if req.PostForm.Get(r.label) != "" {
+				req.PostForm.Del(r.label)
+				newBody := req.PostForm.Encode()
+				// We are replacing request body, close previous one (req.FormValue ensures it is read fully and not nil).
+				_ = req.Body.Close()
+				req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+				req.ContentLength = int64(len(newBody))
+			}
 		}
 
 		h.ServeHTTP(w, req)
@@ -301,6 +303,9 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	var found2 bool
 	// Enforce the query in the POST body if needed.
 	if req.Method == http.MethodPost {
+		if err := req.ParseForm(); err != nil {
+			return
+		}
 		q, found2, err = enforceQueryValues(e, req.PostForm)
 		if err != nil {
 			if _, ok := err.(IllegalLabelMatcherError); ok {
@@ -357,6 +362,9 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 	}
 	req.URL.RawQuery = q.Encode()
 	if req.Method == http.MethodPost {
+		if err := req.ParseForm(); err != nil {
+			return
+		}
 		q = req.PostForm
 		if err := injectMatcher(q, matcher); err != nil {
 			return

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -211,6 +211,10 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 		}
 		req.URL.RawQuery = q.Encode()
 		// Remove the proxy label from the PostForm.
+		if err := req.ParseForm(); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
+			return
+		}
 		if req.PostForm.Get(r.label) != "" {
 			req.PostForm.Del(r.label)
 			newBody := req.PostForm.Encode()
@@ -297,9 +301,6 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	var found2 bool
 	// Enforce the query in the POST body if needed.
 	if req.Method == http.MethodPost {
-		if err := req.ParseForm(); err != nil {
-			return
-		}
 		q, found2, err = enforceQueryValues(e, req.PostForm)
 		if err != nil {
 			if _, ok := err.(IllegalLabelMatcherError); ok {


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

Always parse form when we need to access the request body.