### PR TITLE
adding support for alerts/groups endpoint of alert manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This application proxies the following endpoints and it ensures that a particula
 * `/api/v1/alerts` for GET method (Prometheus/Thanos)
 * `/api/v2/silences` for GET and POST methods (Alertmanager)
 * `/api/v2/silence/` for DELETE (Alertmanager)
+* `/api/v2/alerts/groups` for GET (Alertmanager)
 
 When started with the `-enable-label-apis` flag, the application can also proxy the following endpoints:
 

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -159,6 +159,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 	errs.Add(
 		mux.Handle("/api/v2/silences", r.enforceLabel(enforceMethods(r.silences, "GET", "POST"))),
 		mux.Handle("/api/v2/silence/", r.enforceLabel(enforceMethods(r.deleteSilence, "DELETE"))),
+		mux.Handle("/api/v2/alerts/groups", r.enforceLabel(enforceMethods(r.enforceFilterParameter, "GET"))),
 	)
 
 	if err := errs.Err(); err != nil {

--- a/injectproxy/silences.go
+++ b/injectproxy/silences.go
@@ -35,7 +35,7 @@ import (
 func (r *routes) silences(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case "GET":
-		r.listSilences(w, req)
+		r.enforceFilterParameter(w, req)
 	case "POST":
 		r.postSilence(w, req)
 	default:
@@ -43,7 +43,7 @@ func (r *routes) silences(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (r *routes) listSilences(w http.ResponseWriter, req *http.Request) {
+func (r *routes) enforceFilterParameter(w http.ResponseWriter, req *http.Request) {
 	var (
 		q               = req.URL.Query()
 		proxyLabelMatch = labels.Matcher{

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -531,3 +531,74 @@ func TestUpdateSilence(t *testing.T) {
 		})
 	}
 }
+func TestGetAlertGroups(t *testing.T) {
+	for _, tc := range []struct {
+		labelv         string
+		filters        []string
+		expCode        int
+		expQueryValues []string
+		queryParam     string
+		url            string
+	}{
+		{
+			// No "namespace" parameter returns an error.
+			expCode: http.StatusBadRequest,
+			url:     "http://alertmanager.example.com/api/v2/alerts/groups",
+		},
+		{
+			// Check for other query parameters
+			labelv:         "default",
+			expCode:        http.StatusOK,
+			expQueryValues: []string{"false"},
+			queryParam:     "silenced",
+			url:            "http://alertmanager.example.com/api/v2/alerts/groups?silenced=false",
+		},
+		{
+			// Check for filter parameter.
+			labelv:         "default",
+			filters:        []string{`job="prometheus"`, `instance=~".+"`},
+			expCode:        http.StatusOK,
+			expQueryValues: []string{`job="prometheus"`, `instance=~".+"`, `namespace="default"`},
+			queryParam:     "filter",
+			url:            "http://alertmanager.example.com/api/v2/alerts/groups",
+		},
+	} {
+		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
+			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
+			defer m.Close()
+			r, err := NewRoutes(m.url, proxyLabel)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			q := u.Query()
+			for _, m := range tc.filters {
+				q.Add("filter", m)
+			}
+			q.Set(proxyLabel, tc.labelv)
+			u.RawQuery = q.Encode()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", u.String(), nil)
+			r.ServeHTTP(w, req)
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.expCode {
+				t.Logf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
+				t.Logf("%s", string(body))
+				t.FailNow()
+			}
+			if resp.StatusCode != http.StatusOK {
+				return
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses issue https://github.com/prometheus-community/prom-label-proxy/issues/89 by adding support for alerts/groups endpoint in alert manager