### PR TITLE
fix: returning correct http status code in case of failures

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -75,7 +75,7 @@ func WithPassthroughPaths(paths []string) Option {
 	})
 }
 
-// ErrorOnReplace causes the proxy to return 403 if a label matcher we want to
+// WithErrorOnReplace causes the proxy to return 400 if a label matcher we want to
 // inject is present in the query already and matches something different
 func WithErrorOnReplace() Option {
 	return optionFunc(func(o *options) {
@@ -294,8 +294,13 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	// enforce in both places.
 	q, found1, err := enforceQueryValues(e, req.URL.Query())
 	if err != nil {
-		if _, ok := err.(IllegalLabelMatcherError); ok {
+		switch err.(type) {
+		case IllegalLabelMatcherError:
 			http.Error(w, err.Error(), http.StatusBadRequest)
+		case queryParseError:
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case enforceLabelError:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		return
 	}
@@ -305,12 +310,17 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	// Enforce the query in the POST body if needed.
 	if req.Method == http.MethodPost {
 		if err := req.ParseForm(); err != nil {
-			return
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		q, found2, err = enforceQueryValues(e, req.PostForm)
 		if err != nil {
-			if _, ok := err.(IllegalLabelMatcherError); ok {
+			switch err.(type) {
+			case IllegalLabelMatcherError:
 				http.Error(w, err.Error(), http.StatusBadRequest)
+			case queryParseError:
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			case enforceLabelError:
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 			return
 		}
@@ -337,11 +347,16 @@ func enforceQueryValues(e *Enforcer, v url.Values) (values string, noQuery bool,
 	}
 	expr, err := parser.ParseExpr(v.Get(queryParam))
 	if err != nil {
-		return "", true, err
+		queryParseError := newQueryParseError(err)
+		return "", true, queryParseError
 	}
 
 	if err := e.EnforceNode(expr); err != nil {
-		return "", true, err
+		if _, ok := err.(IllegalLabelMatcherError); ok {
+			return "", true, err
+		}
+		enforceLabelError := newEnforceLabelError(err)
+		return "", true, enforceLabelError
 	}
 
 	v.Set(queryParam, expr.String())
@@ -404,4 +419,28 @@ func matchersToString(ms ...*labels.Matcher) string {
 		el = append(el, m.String())
 	}
 	return fmt.Sprintf("{%v}", strings.Join(el, ","))
+}
+
+type queryParseError struct {
+	msg string
+}
+
+func (e queryParseError) Error() string {
+	return e.msg
+}
+
+func newQueryParseError(err error) queryParseError {
+	return queryParseError{msg: fmt.Sprintf("error parsing query string %q", err.Error())}
+}
+
+type enforceLabelError struct {
+	msg string
+}
+
+func (e enforceLabelError) Error() string {
+	return e.msg
+}
+
+func newEnforceLabelError(err error) enforceLabelError {
+	return enforceLabelError{msg: fmt.Sprintf("error enforcing label %q", err.Error())}
 }

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -818,17 +818,17 @@ func TestQuery(t *testing.T) {
 			expResponse:      okResponse,
 		},
 		{
-			name:      `An invalid expression returns 200 with empty body`,
+			name:      `An invalid expression returns 400 with error response`,
 			labelv:    "default",
 			promQuery: "up +",
-			expCode:   http.StatusOK,
+			expCode:   http.StatusBadRequest,
 		},
 		{
-			name:          `An invalid expression in POST body returns 200 with empty body`,
+			name:          `An invalid expression in POST body returns 400 with error response`,
 			labelv:        "default",
 			promQueryBody: "up +",
 			method:        http.MethodPost,
-			expCode:       http.StatusOK,
+			expCode:       http.StatusBadRequest,
 		},
 		{
 			name:         `Binary expression`,


### PR DESCRIPTION
Fixes  https://github.com/prometheus-community/prom-label-proxy/issues/51

Signed-off-by: Prashant Balachandran <pnair@redhat.com>