### PR TITLE
Added support for regex label

### DIFF
--- a/injectproxy/rules.go
+++ b/injectproxy/rules.go
@@ -175,7 +175,7 @@ func modifyAPIResponse(f func(string, *apiResponse) (interface{}, error)) func(*
 			return errors.Wrap(err, "can't decode API response")
 		}
 
-		v, err := f(mustLabelValue(resp.Request.Context()), apir)
+		v, err := f(mustLabelMatcher(resp.Request.Context()).Value, apir)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR about support regex label #27. 
Main idea is to recognise matcher from query and keep matcher instead label in context.
It allow to use multiple namespaces via query like `namespace=~kube-system|openshift-monitoring` and still works with one namespace without regex. 