### PR TITLE
feat: Send errors in prometheus rest api format

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -207,7 +207,7 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		lvalue := req.FormValue(r.label)
 		if lvalue == "" {
-			http.Error(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
+			prometheusAPIError(w, fmt.Sprintf("Bad request. The %q query parameter must be provided.", r.label), http.StatusBadRequest)
 			return
 		}
 		req = req.WithContext(withLabelValue(req.Context(), lvalue))
@@ -221,7 +221,7 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 		// Remove the proxy label from the PostForm.
 		if req.Method == http.MethodPost {
 			if err := req.ParseForm(); err != nil {
-				http.Error(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
+				prometheusAPIError(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
 				return
 			}
 			if req.PostForm.Get(r.label) != "" {
@@ -303,11 +303,11 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		switch err.(type) {
 		case IllegalLabelMatcherError:
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			prometheusAPIError(w, err.Error(), http.StatusBadRequest)
 		case queryParseError:
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			prometheusAPIError(w, err.Error(), http.StatusBadRequest)
 		case enforceLabelError:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			prometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 		}
 		return
 	}
@@ -317,17 +317,17 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 	// Enforce the query in the POST body if needed.
 	if req.Method == http.MethodPost {
 		if err := req.ParseForm(); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			prometheusAPIError(w, err.Error(), http.StatusBadRequest)
 		}
 		q, found2, err = enforceQueryValues(e, req.PostForm)
 		if err != nil {
 			switch err.(type) {
 			case IllegalLabelMatcherError:
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				prometheusAPIError(w, err.Error(), http.StatusBadRequest)
 			case queryParseError:
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				prometheusAPIError(w, err.Error(), http.StatusBadRequest)
 			case enforceLabelError:
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				prometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 			}
 			return
 		}

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -32,11 +32,11 @@ func checkParameterAbsent(param string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		kvs, err := url.ParseQuery(req.URL.RawQuery)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
 			return
 		}
 		if len(kvs[param]) != 0 {
-			http.Error(w, fmt.Sprintf("unexpected parameter %q", param), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected parameter %q", param), http.StatusInternalServerError)
 			return
 		}
 		next.ServeHTTP(w, req)
@@ -47,12 +47,12 @@ func checkFormParameterAbsent(param string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		err := req.ParseForm()
 		if err != nil {
-			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
 			return
 		}
 		kvs := req.Form
 		if len(kvs[param]) != 0 {
-			http.Error(w, fmt.Sprintf("unexpected Form parameter %q", param), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected Form parameter %q", param), http.StatusInternalServerError)
 			return
 		}
 		next.ServeHTTP(w, req)
@@ -64,29 +64,29 @@ func checkQueryHandler(body, key string, values ...string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		kvs, err := url.ParseQuery(req.URL.RawQuery)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
 			return
 		}
 		// Verify that the client provides the parameter only once.
 		if len(kvs[key]) != len(values) {
-			http.Error(w, fmt.Sprintf("expected %d values of parameter %q, got %d", len(values), key, len(kvs[key])), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("expected %d values of parameter %q, got %d", len(values), key, len(kvs[key])), http.StatusInternalServerError)
 			return
 		}
 		sort.Strings(values)
 		sort.Strings(kvs[key])
 		for i := range values {
 			if kvs[key][i] != values[i] {
-				http.Error(w, fmt.Sprintf("expected parameter %q with value %q, got %q", key, values[i], kvs[key][i]), http.StatusInternalServerError)
+				prometheusAPIError(w, fmt.Sprintf("expected parameter %q with value %q, got %q", key, values[i], kvs[key][i]), http.StatusInternalServerError)
 				return
 			}
 		}
 		buf, err := ioutil.ReadAll(req.Body)
 		if err != nil {
-			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			prometheusAPIError(w, "failed to read body", http.StatusInternalServerError)
 			return
 		}
 		if string(buf) != body {
-			http.Error(w, fmt.Sprintf("expected body %q, got %q", body, string(buf)), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("expected body %q, got %q", body, string(buf)), http.StatusInternalServerError)
 			return
 		}
 
@@ -100,20 +100,20 @@ func checkFormHandler(key string, values ...string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		err := req.ParseForm()
 		if err != nil {
-			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
 			return
 		}
 		kvs := req.PostForm
 		// Verify that the client provides the parameter only once.
 		if len(kvs[key]) != len(values) {
-			http.Error(w, fmt.Sprintf("expected %d values of parameter %q, got %d", len(values), key, len(kvs[key])), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("expected %d values of parameter %q, got %d", len(values), key, len(kvs[key])), http.StatusInternalServerError)
 			return
 		}
 		sort.Strings(values)
 		sort.Strings(kvs[key])
 		for i := range values {
 			if kvs[key][i] != values[i] {
-				http.Error(w, fmt.Sprintf("expected parameter %q with value %q, got %q", key, values[i], kvs[key][i]), http.StatusInternalServerError)
+				prometheusAPIError(w, fmt.Sprintf("expected parameter %q with value %q, got %q", key, values[i], kvs[key][i]), http.StatusInternalServerError)
 				return
 			}
 		}

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -338,7 +338,7 @@ func TestRules(t *testing.T) {
 		{
 			// No "namespace" parameter returns an error.
 			expCode: http.StatusBadRequest,
-			expBody: []byte("Bad request. The \"namespace\" query parameter must be provided.\n"),
+			expBody: []byte(`{"error":"Bad request. The \"namespace\" query parameter must be provided.","errorType":"prom-label-proxy","status":"error"}` + "\n"),
 		},
 		{
 			// non 200 status code from upstream is passed as-is.
@@ -719,7 +719,7 @@ func TestAlerts(t *testing.T) {
 		{
 			// No "namespace" parameter returns an error.
 			expCode: http.StatusBadRequest,
-			expBody: []byte("Bad request. The \"namespace\" query parameter must be provided.\n"),
+			expBody: []byte(`{"error":"Bad request. The \"namespace\" query parameter must be provided.","errorType":"prom-label-proxy","status":"error"}` + "\n"),
 		},
 		{
 			// non 200 status code from upstream is passed as-is.

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -118,11 +118,11 @@ const silID = "802146e0-1f7a-42a6-ab0e-1e631479970b"
 func getSilenceWithoutLabel() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != "GET" {
-			http.Error(w, "invalid method: "+req.Method, http.StatusInternalServerError)
+			prometheusAPIError(w, "invalid method: "+req.Method, http.StatusInternalServerError)
 			return
 		}
 		if req.URL.Path != "/api/v2/silence/"+silID {
-			http.Error(w, "invalid path: "+req.URL.Path, http.StatusInternalServerError)
+			prometheusAPIError(w, "invalid path: "+req.URL.Path, http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -152,11 +152,11 @@ func getSilenceWithoutLabel() http.Handler {
 func getSilenceWithLabel(labelv string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != "GET" {
-			http.Error(w, "invalid method: "+req.Method, http.StatusInternalServerError)
+			prometheusAPIError(w, "invalid method: "+req.Method, http.StatusInternalServerError)
 			return
 		}
 		if req.URL.Path != "/api/v2/silence/"+silID {
-			http.Error(w, "invalid path: "+req.URL.Path, http.StatusInternalServerError)
+			prometheusAPIError(w, "invalid path: "+req.URL.Path, http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -187,7 +187,7 @@ func createSilenceWithLabel(labelv string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var sil models.PostableSilence
 		if err := json.NewDecoder(req.Body).Decode(&sil); err != nil {
-			http.Error(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("unexpected error: %v", err), http.StatusInternalServerError)
 			return
 		}
 		var values []string
@@ -197,11 +197,11 @@ func createSilenceWithLabel(labelv string) http.Handler {
 			}
 		}
 		if len(values) != 1 {
-			http.Error(w, fmt.Sprintf("expected 1 matcher for label %s, got %d", proxyLabel, len(values)), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("expected 1 matcher for label %s, got %d", proxyLabel, len(values)), http.StatusInternalServerError)
 			return
 		}
 		if values[0] != labelv {
-			http.Error(w, fmt.Sprintf("expected matcher for label %s to be %q, got %q", proxyLabel, labelv, values[0]), http.StatusInternalServerError)
+			prometheusAPIError(w, fmt.Sprintf("expected matcher for label %s to be %q, got %q", proxyLabel, labelv, values[0]), http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -219,7 +219,7 @@ func (c *chainedHandlers) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer func() { c.idx++ }()
 
 	if c.idx >= len(c.handlers) {
-		http.Error(w, "", http.StatusInternalServerError)
+		prometheusAPIError(w, "", http.StatusInternalServerError)
 		return
 	}
 	c.handlers[c.idx].ServeHTTP(w, req)

--- a/injectproxy/utils.go
+++ b/injectproxy/utils.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package injectproxy
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+func prometheusAPIError(w http.ResponseWriter, errorMessage string, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+
+	res := map[string]string{"status": "error", "errorType": "prom-label-proxy", "error": errorMessage}
+
+	if err := json.NewEncoder(w).Encode(res); err != nil {
+		log.Printf("error: Failed to encode json: %v", err)
+	}
+}


### PR DESCRIPTION
This PR changes the format of all error related http responses.

Instead send error as plain text, capsule the error into a json that follows normal prometheus API responses. https://prometheus.io/docs/prometheus/latest/querying/api/#http-api

The motivations of this change is to make errors visible in Grafana. Otherwise, errors are hard to debug, since the errors are not logged.

Before:
![grafana-error](https://user-images.githubusercontent.com/1560587/172402720-91a95879-525b-4d43-af39-9bf3af39c04e.png)

After:
![image](https://user-images.githubusercontent.com/1560587/172402958-36cb0bc7-140d-41cf-8bb1-b4da9e641061.png)


