### PR TITLE
Allow setting static label value on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The "tenant" query parameter must be provided.
 {"status":"success","data":{"resultType":"vector","result":[]}}%
 ```
 
-You can also provide a static value for the tenancy label. For example, running `prom-label-proxy` with
+You can also provide a static value for a label. For example, running `prom-label-proxy` with
 ```
 prom-label-proxy \
    -label tenant \

--- a/README.md
+++ b/README.md
@@ -70,10 +70,23 @@ Accessing demo Prometheus APIs on `127.0.0.1:8080` will now expect `tenant` quer
 
 ```bash
 ➜  ~ curl http://127.0.0.1:8080/api/v1/query\?query="up"
-Bad request. The "tenant" query parameter must be provided.
+The "tenant" query parameter must be provided.
 ➜  ~ curl http://127.0.0.1:8080/api/v1/query\?query="up"\&tenant\="something"
 {"status":"success","data":{"resultType":"vector","result":[]}}%
 ```
+
+You can also provide a static value for the tenancy label. For example, running `prom-label-proxy` with
+```
+prom-label-proxy \
+   -label tenant \
+   -value prometheus \
+   -upstream http://demo.do.prometheus.io:9090 \
+   -insecure-listen-address 127.0.0.1:8080
+```
+will enforce `tenant=prometheus` in all requests.
+
+
+In this mode, sending the label value as a query parameter will result in the request getting rejected as a 400 Bad Request.
 
 Once again for clarity: **this project only enforces a particular label in the respective calls to Prometheus, it in itself does not authenticate or
 authorize the requesting entity in any way, this has to be built around this project.**

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -266,7 +266,7 @@ func (r *routes) getLabelValue(req *http.Request) (string, error) {
 	}
 
 	if r.labelValue == "" && formValue == "" {
-		return "", fmt.Errorf("bad request. The %q query parameter must be provided", r.label)
+		return "", fmt.Errorf("the %q query parameter must be provided", r.label)
 	}
 
 	if r.labelValue != "" {

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -338,7 +338,7 @@ func TestRules(t *testing.T) {
 		{
 			// No "namespace" parameter returns an error.
 			expCode: http.StatusBadRequest,
-			expBody: []byte(`{"error":"Bad request. The \"namespace\" query parameter must be provided.","errorType":"prom-label-proxy","status":"error"}` + "\n"),
+			expBody: []byte(`{"error":"The \"namespace\" query parameter must be provided.","errorType":"prom-label-proxy","status":"error"}` + "\n"),
 		},
 		{
 			// non 200 status code from upstream is passed as-is.
@@ -719,7 +719,7 @@ func TestAlerts(t *testing.T) {
 		{
 			// No "namespace" parameter returns an error.
 			expCode: http.StatusBadRequest,
-			expBody: []byte(`{"error":"Bad request. The \"namespace\" query parameter must be provided.","errorType":"prom-label-proxy","status":"error"}` + "\n"),
+			expBody: []byte(`{"error":"The \"namespace\" query parameter must be provided.","errorType":"prom-label-proxy","status":"error"}` + "\n"),
 		},
 		{
 			// non 200 status code from upstream is passed as-is.

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 		insecureListenAddress  string
 		upstream               string
 		label                  string
+		labelValue             string
 		enableLabelAPIs        bool
 		unsafePassthroughPaths string // Comma-delimited string.
 		errorOnReplace         bool
@@ -43,6 +44,8 @@ func main() {
 	flagset.StringVar(&label, "label", "", "The label to enforce in all proxied PromQL queries. "+
 		"This label will be also required as the URL parameter to get the value to be injected. For example: -label=tenant will"+
 		" make it required for this proxy to have URL in form of: <URL>?tenant=abc&other_params...")
+	flagset.StringVar(&labelValue, "label-value", "", "A fixed label value to enforce in all proxied PromQL queries. "+
+		"When this flag is not set, the label value will be taken from the URL parameter defined by the label flag.")
 	flagset.BoolVar(&enableLabelAPIs, "enable-label-apis", false, "When specified proxy allows to inject label to label APIs like /api/v1/labels and /api/v1/label/<name>/values. "+
 		"NOTE: Enable with care because filtering by matcher is not implemented in older versions of Prometheus (>= v2.24.0 required) and Thanos (>= v0.18.0 required, >= v0.23.0 recommended). If enabled and "+
 		"any labels endpoint does not support selectors, the injected matcher will have no effect.")
@@ -76,6 +79,10 @@ func main() {
 	if errorOnReplace {
 		opts = append(opts, injectproxy.WithErrorOnReplace())
 	}
+	if labelValue != "" {
+		opts = append(opts, injectproxy.WithLabelValue(labelValue))
+	}
+
 	routes, err := injectproxy.NewRoutes(upstreamURL, label, opts...)
 	if err != nil {
 		log.Fatalf("Failed to create injectproxy Routes: %v", err)


### PR DESCRIPTION
This commit implements a -label-value flag which allows setting a static
label value when running prom-label-proxy. When this flag is set,
requests which contain a label value in the URL will get rejected
with a bad response status code.