### PR TITLE
feat: add /metrics endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.24.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/prometheus v0.35.0
 )
 
@@ -39,7 +40,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.34.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/efficientgo/tools/core/pkg/merrors"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -184,6 +185,7 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 		mux.Handle("/healthz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
 		})),
+		mux.Handle("/metrics", promhttp.Handler()),
 	)
 
 	if err := errs.Err(); err != nil {


### PR DESCRIPTION
Adds a `/metrics` endpoint to expose default Go metrics.

I initially went for adding this to the existent listener, but if needed be, we can create a dedicated listener for metrics only.