### PR TITLE
chore: remove usage of io/ioutil

### DIFF
--- a/injectproxy/alerts_test.go
+++ b/injectproxy/alerts_test.go
@@ -14,7 +14,7 @@
 package injectproxy
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -86,7 +86,7 @@ func TestGetAlerts(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			defer resp.Body.Close()
 
 			if resp.StatusCode != tc.expCode {

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -283,7 +283,7 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 				newBody := req.PostForm.Encode()
 				// We are replacing request body, close previous one (req.FormValue ensures it is read fully and not nil).
 				_ = req.Body.Close()
-				req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+				req.Body = io.NopCloser(strings.NewReader(newBody))
 				req.ContentLength = int64(len(newBody))
 			}
 		}
@@ -407,7 +407,7 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 		}
 		// We are replacing request body, close previous one (ParseForm ensures it is read fully and not nil).
 		_ = req.Body.Close()
-		req.Body = ioutil.NopCloser(strings.NewReader(q))
+		req.Body = io.NopCloser(strings.NewReader(q))
 		req.ContentLength = int64(len(q))
 	}
 
@@ -470,7 +470,7 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 		// We are replacing request body, close previous one (ParseForm ensures it is read fully and not nil).
 		_ = req.Body.Close()
 		newBody := q.Encode()
-		req.Body = ioutil.NopCloser(strings.NewReader(newBody))
+		req.Body = io.NopCloser(strings.NewReader(newBody))
 		req.ContentLength = int64(len(newBody))
 	}
 	r.handler.ServeHTTP(w, req)

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -16,7 +16,6 @@ package injectproxy
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -80,7 +79,7 @@ func checkQueryHandler(body, key string, values ...string) http.Handler {
 				return
 			}
 		}
-		buf, err := ioutil.ReadAll(req.Body)
+		buf, err := io.ReadAll(req.Body)
 		if err != nil {
 			prometheusAPIError(w, "failed to read body", http.StatusInternalServerError)
 			return
@@ -249,7 +248,7 @@ func TestWithPassthroughPaths(t *testing.T) {
 			r.ServeHTTP(w, httptest.NewRequest(tcase.method, tcase.url, nil))
 			resp := w.Result()
 			if resp.StatusCode != tcase.expCode {
-				b, err := ioutil.ReadAll(resp.Body)
+				b, err := io.ReadAll(resp.Body)
 				fmt.Println(string(b), err)
 				t.Fatalf("expected status code %v, got %d", tcase.expCode, resp.StatusCode)
 			}
@@ -336,7 +335,7 @@ func TestMatch(t *testing.T) {
 				r.ServeHTTP(w, req)
 
 				resp := w.Result()
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				defer resp.Body.Close()
 
 				if resp.StatusCode != tc.expCode {
@@ -433,7 +432,7 @@ func TestMatchWithPost(t *testing.T) {
 				r.ServeHTTP(w, req)
 
 				resp := w.Result()
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				defer resp.Body.Close()
 
 				if resp.StatusCode != tc.expCode {
@@ -534,7 +533,7 @@ func TestSeries(t *testing.T) {
 
 				resp := w.Result()
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -646,7 +645,7 @@ func TestSeriesWithPost(t *testing.T) {
 
 				resp := w.Result()
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -900,7 +899,7 @@ func TestQuery(t *testing.T) {
 				r.ServeHTTP(w, req)
 
 				resp := w.Result()
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}

--- a/injectproxy/rules.go
+++ b/injectproxy/rules.go
@@ -18,7 +18,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -190,7 +190,7 @@ func modifyAPIResponse(f func(string, *apiResponse) (interface{}, error)) func(*
 		if err = json.NewEncoder(&buf).Encode(apir); err != nil {
 			return errors.Wrap(err, "can't encode API response")
 		}
-		resp.Body = ioutil.NopCloser(&buf)
+		resp.Body = io.NopCloser(&buf)
 		resp.Header["Content-Length"] = []string{fmt.Sprint(buf.Len())}
 
 		return nil

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -686,7 +685,7 @@ func TestRules(t *testing.T) {
 				t.Fatalf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
 			}
 
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			if resp.StatusCode != http.StatusOK {
 				if string(body) != string(tc.expBody) {
 					t.Fatalf("expected: %q, got: %q", string(tc.expBody), string(body))
@@ -860,7 +859,7 @@ func TestAlerts(t *testing.T) {
 				t.Fatalf("expected status code %d, got %d", tc.expCode, resp.StatusCode)
 			}
 
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			if resp.StatusCode != http.StatusOK {
 				if string(body) != string(tc.expBody) {
 					t.Fatalf("expected: %q, got: %q", string(tc.expBody), string(body))

--- a/injectproxy/silences.go
+++ b/injectproxy/silences.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"strconv"
@@ -121,7 +121,7 @@ func (r *routes) postSilence(w http.ResponseWriter, req *http.Request) {
 	}
 
 	req = req.Clone(req.Context())
-	req.Body = ioutil.NopCloser(&buf)
+	req.Body = io.NopCloser(&buf)
 	req.URL.RawQuery = ""
 	req.Header["Content-Length"] = []string{strconv.Itoa(buf.Len())}
 	req.ContentLength = int64(buf.Len())

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -94,7 +94,7 @@ func TestListSilences(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			defer resp.Body.Close()
 
 			if resp.StatusCode != tc.expCode {
@@ -318,7 +318,7 @@ func TestDeleteSilence(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			defer resp.Body.Close()
 
 			if resp.StatusCode != tc.expCode {
@@ -513,7 +513,7 @@ func TestUpdateSilence(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			defer resp.Body.Close()
 
 			if resp.StatusCode != tc.expCode {
@@ -587,7 +587,7 @@ func TestGetAlertGroups(t *testing.T) {
 			r.ServeHTTP(w, req)
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			defer resp.Body.Close()
 
 			if resp.StatusCode != tc.expCode {


### PR DESCRIPTION
The package is deprecated since Go 1.16.

Signed-off-by: Simon Pasquier <spasquie@redhat.com>