### PR TITLE
feat: update /api/v1/{rules,alerts} responses

### DIFF
--- a/injectproxy/rules.go
+++ b/injectproxy/rules.go
@@ -126,24 +126,30 @@ func (r *rule) UnmarshalJSON(b []byte) error {
 }
 
 type alertingRule struct {
-	Name        string        `json:"name"`
-	Query       string        `json:"query"`
-	Duration    float64       `json:"duration"`
-	Labels      labels.Labels `json:"labels"`
-	Annotations labels.Labels `json:"annotations"`
-	Alerts      []*alert      `json:"alerts"`
-	Health      string        `json:"health"`
-	LastError   string        `json:"lastError,omitempty"`
+	State          string        `json:"state"`
+	Name           string        `json:"name"`
+	Query          string        `json:"query"`
+	Duration       float64       `json:"duration"`
+	KeepFiringFor  float64       `json:"keepFiringFor"`
+	Labels         labels.Labels `json:"labels"`
+	Annotations    labels.Labels `json:"annotations"`
+	Alerts         []*alert      `json:"alerts"`
+	Health         string        `json:"health"`
+	LastError      string        `json:"lastError,omitempty"`
+	EvaluationTime float64       `json:"evaluationTime"`
+	LastEvaluation time.Time     `json:"lastEvaluation"`
 	// Type of an alertingRule is always "alerting".
 	Type string `json:"type"`
 }
 
 type recordingRule struct {
-	Name      string        `json:"name"`
-	Query     string        `json:"query"`
-	Labels    labels.Labels `json:"labels,omitempty"`
-	Health    string        `json:"health"`
-	LastError string        `json:"lastError,omitempty"`
+	Name           string        `json:"name"`
+	Query          string        `json:"query"`
+	Labels         labels.Labels `json:"labels,omitempty"`
+	Health         string        `json:"health"`
+	LastError      string        `json:"lastError,omitempty"`
+	EvaluationTime float64       `json:"evaluationTime"`
+	LastEvaluation time.Time     `json:"lastEvaluation"`
 	// Type of a recordingRule is always "recording".
 	Type string `json:"type"`
 }
@@ -153,11 +159,12 @@ type alertsData struct {
 }
 
 type alert struct {
-	Labels      labels.Labels `json:"labels"`
-	Annotations labels.Labels `json:"annotations"`
-	State       string        `json:"state"`
-	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
-	Value       string        `json:"value"`
+	Labels          labels.Labels `json:"labels"`
+	Annotations     labels.Labels `json:"annotations"`
+	State           string        `json:"state"`
+	ActiveAt        *time.Time    `json:"activeAt,omitempty"`
+	KeepFiringSince *time.Time    `json:"keepFiringSince,omitempty"`
+	Value           string        `json:"value"`
 }
 
 // modifyAPIResponse unwraps the Prometheus API response, passes the enforced

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -64,7 +64,9 @@ func validRules() http.Handler {
               "namespace": "ns1"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214303,
+            "lastEvaluation": "2024-04-29T14:23:52.403557247+02:00"
           },
           {
             "name": "metric2",
@@ -74,7 +76,9 @@ func validRules() http.Handler {
               "operation": "create"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.403557247+02:00"
           },
           {
             "name": "metric2",
@@ -84,7 +88,9 @@ func validRules() http.Handler {
               "operation": "update"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:54.403557247+02:00"
           },
           {
             "name": "metric2",
@@ -94,9 +100,12 @@ func validRules() http.Handler {
               "operation": "delete"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.603557247+02:00"
           },
           {
+            "state": "firing",
             "name": "Alert1",
             "query": "metric1{namespace=\"ns1\"} == 0",
             "duration": 0,
@@ -117,9 +126,12 @@ func validRules() http.Handler {
               }
             ],
             "health": "ok",
-            "type": "alerting"
+            "type": "alerting",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.803557247+02:00"
           },
           {
+            "state": "firing",
             "name": "Alert2",
             "query": "metric2{namespace=\"ns1\"} == 0",
             "duration": 0,
@@ -152,7 +164,9 @@ func validRules() http.Handler {
               }
             ],
             "health": "ok",
-            "type": "alerting"
+            "type": "alerting",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.903557247+02:00"
           }
         ],
         "interval": 10
@@ -168,9 +182,12 @@ func validRules() http.Handler {
               "namespace": "ns2"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214303,
+            "lastEvaluation": "2024-04-29T14:23:52.403557247+02:00"
           },
           {
+            "state": "inactive",
             "name": "Alert1",
             "query": "metric1{namespace=\"ns2\"} == 0",
             "duration": 0,
@@ -180,7 +197,9 @@ func validRules() http.Handler {
             "annotations": {},
             "alerts": [],
             "health": "ok",
-            "type": "alerting"
+            "type": "alerting",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.503557247+02:00"
           }
         ],
         "interval": 10
@@ -197,7 +216,9 @@ func validRules() http.Handler {
               "operation": "create"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.503557247+02:00"
           },
           {
             "name": "metric2",
@@ -207,7 +228,9 @@ func validRules() http.Handler {
               "operation": "update"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.603557247+02:00"
           },
           {
             "name": "metric2",
@@ -217,7 +240,9 @@ func validRules() http.Handler {
               "operation": "delete"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.643557247+02:00"
           },
           {
             "name": "metric3",
@@ -226,9 +251,12 @@ func validRules() http.Handler {
               "namespace": "ns2"
             },
             "health": "ok",
-            "type": "recording"
+            "type": "recording",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.683557247+02:00"
           },
           {
+            "state": "inactive",
             "name": "Alert2",
             "query": "metric2{namespace=\"ns2\"} == 0",
             "duration": 0,
@@ -238,9 +266,12 @@ func validRules() http.Handler {
             "annotations": {},
             "alerts": [],
             "health": "ok",
-            "type": "alerting"
+            "type": "alerting",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.803557247+02:00"
           },
           {
+            "state": "firing",
             "name": "Alert3",
             "query": "metric3{namespace=\"ns2\"} == 0",
             "duration": 0,
@@ -261,7 +292,9 @@ func validRules() http.Handler {
               }
             ],
             "health": "ok",
-            "type": "alerting"
+            "type": "alerting",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.903557247+02:00"
           }
         ],
         "interval": 10

--- a/injectproxy/testdata/rules_match_namespace_ns1.golden
+++ b/injectproxy/testdata/rules_match_namespace_ns1.golden
@@ -13,6 +13,8 @@
               "namespace": "ns1"
             },
             "health": "ok",
+            "evaluationTime": 0.000214303,
+            "lastEvaluation": "2024-04-29T14:23:52.403557247+02:00",
             "type": "recording"
           },
           {
@@ -23,6 +25,8 @@
               "operation": "create"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.403557247+02:00",
             "type": "recording"
           },
           {
@@ -33,6 +37,8 @@
               "operation": "update"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:54.403557247+02:00",
             "type": "recording"
           },
           {
@@ -43,12 +49,16 @@
               "operation": "delete"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.603557247+02:00",
             "type": "recording"
           },
           {
+            "state": "firing",
             "name": "Alert1",
             "query": "metric1{namespace=\"ns1\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns1"
             },
@@ -66,12 +76,16 @@
               }
             ],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.803557247+02:00",
             "type": "alerting"
           },
           {
+            "state": "firing",
             "name": "Alert2",
             "query": "metric2{namespace=\"ns1\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns1"
             },
@@ -101,6 +115,8 @@
               }
             ],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.903557247+02:00",
             "type": "alerting"
           }
         ],

--- a/injectproxy/testdata/rules_match_namespace_ns2.golden
+++ b/injectproxy/testdata/rules_match_namespace_ns2.golden
@@ -13,18 +13,24 @@
               "namespace": "ns2"
             },
             "health": "ok",
+            "evaluationTime": 0.000214303,
+            "lastEvaluation": "2024-04-29T14:23:52.403557247+02:00",
             "type": "recording"
           },
           {
+            "state": "inactive",
             "name": "Alert1",
             "query": "metric1{namespace=\"ns2\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns2"
             },
             "annotations": {},
             "alerts": [],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.503557247+02:00",
             "type": "alerting"
           }
         ],
@@ -42,6 +48,8 @@
               "operation": "create"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.503557247+02:00",
             "type": "recording"
           },
           {
@@ -52,6 +60,8 @@
               "operation": "update"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.603557247+02:00",
             "type": "recording"
           },
           {
@@ -62,6 +72,8 @@
               "operation": "delete"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.643557247+02:00",
             "type": "recording"
           },
           {
@@ -71,24 +83,32 @@
               "namespace": "ns2"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.683557247+02:00",
             "type": "recording"
           },
           {
+            "state": "inactive",
             "name": "Alert2",
             "query": "metric2{namespace=\"ns2\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns2"
             },
             "annotations": {},
             "alerts": [],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.803557247+02:00",
             "type": "alerting"
           },
           {
+            "state": "firing",
             "name": "Alert3",
             "query": "metric3{namespace=\"ns2\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns2"
             },
@@ -106,6 +126,8 @@
               }
             ],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.903557247+02:00",
             "type": "alerting"
           }
         ],

--- a/injectproxy/testdata/rules_match_namespaces_ns1_and_ns2.golden
+++ b/injectproxy/testdata/rules_match_namespaces_ns1_and_ns2.golden
@@ -13,6 +13,8 @@
               "namespace": "ns1"
             },
             "health": "ok",
+            "evaluationTime": 0.000214303,
+            "lastEvaluation": "2024-04-29T14:23:52.403557247+02:00",
             "type": "recording"
           },
           {
@@ -23,6 +25,8 @@
               "operation": "create"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.403557247+02:00",
             "type": "recording"
           },
           {
@@ -33,6 +37,8 @@
               "operation": "update"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:54.403557247+02:00",
             "type": "recording"
           },
           {
@@ -43,12 +49,16 @@
               "operation": "delete"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.603557247+02:00",
             "type": "recording"
           },
           {
+            "state": "firing",
             "name": "Alert1",
             "query": "metric1{namespace=\"ns1\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns1"
             },
@@ -66,12 +76,16 @@
               }
             ],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.803557247+02:00",
             "type": "alerting"
           },
           {
+            "state": "firing",
             "name": "Alert2",
             "query": "metric2{namespace=\"ns1\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns1"
             },
@@ -101,6 +115,8 @@
               }
             ],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:53.903557247+02:00",
             "type": "alerting"
           }
         ],
@@ -117,18 +133,24 @@
               "namespace": "ns2"
             },
             "health": "ok",
+            "evaluationTime": 0.000214303,
+            "lastEvaluation": "2024-04-29T14:23:52.403557247+02:00",
             "type": "recording"
           },
           {
+            "state": "inactive",
             "name": "Alert1",
             "query": "metric1{namespace=\"ns2\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns2"
             },
             "annotations": {},
             "alerts": [],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.503557247+02:00",
             "type": "alerting"
           }
         ],
@@ -146,6 +168,8 @@
               "operation": "create"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.503557247+02:00",
             "type": "recording"
           },
           {
@@ -156,6 +180,8 @@
               "operation": "update"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.603557247+02:00",
             "type": "recording"
           },
           {
@@ -166,6 +192,8 @@
               "operation": "delete"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.643557247+02:00",
             "type": "recording"
           },
           {
@@ -175,24 +203,32 @@
               "namespace": "ns2"
             },
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.683557247+02:00",
             "type": "recording"
           },
           {
+            "state": "inactive",
             "name": "Alert2",
             "query": "metric2{namespace=\"ns2\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns2"
             },
             "annotations": {},
             "alerts": [],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.803557247+02:00",
             "type": "alerting"
           },
           {
+            "state": "firing",
             "name": "Alert3",
             "query": "metric3{namespace=\"ns2\"} == 0",
             "duration": 0,
+            "keepFiringFor": 0,
             "labels": {
               "namespace": "ns2"
             },
@@ -210,6 +246,8 @@
               }
             ],
             "health": "ok",
+            "evaluationTime": 0.000214,
+            "lastEvaluation": "2024-04-29T14:23:52.903557247+02:00",
             "type": "alerting"
           }
         ],


### PR DESCRIPTION
This commit adds the fields supported by newer Prometheus versions:

* /api/v1/rules
  * `state` (for alerting rules only)
  * `keepFiringFor` (for alerting rules only)
  * `evaluationTime`
  * `lastEvaluation`
* /api/v1/alerts
  * `keepFiringSince`