### PR TITLE
Adds the optional ability to split the tenant request header by comma

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 		unsafePassthroughPaths string // Comma-delimited string.
 		errorOnReplace         bool
 		regexMatch             bool
+		headerUsesListSyntax   bool
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -84,6 +85,7 @@ func main() {
 		"API (like /api/v1/configuration) which isn't enforced by prom-label-proxy. NOTE: \"all\" matching paths like \"/\" or \"\" and regex are not allowed.")
 	flagset.BoolVar(&errorOnReplace, "error-on-replace", false, "When specified, the proxy will return HTTP status code 400 if the query already contains a label matcher that differs from the one the proxy would inject.")
 	flagset.BoolVar(&regexMatch, "regex-match", false, "When specified, the tenant name is treated as a regular expression. In this case, only one tenant name should be provided.")
+	flagset.BoolVar(&headerUsesListSyntax, "header-uses-list-syntax", false, "When specified, the header line value will be parsed as a comma-separated list. This allows a single tenant header line to specify multiple tenant names.")
 
 	//nolint: errcheck // Parse() will exit on error.
 	flagset.Parse(os.Args[1:])
@@ -154,7 +156,7 @@ func main() {
 	case queryParam != "":
 		extractLabeler = injectproxy.HTTPFormEnforcer{ParameterName: queryParam}
 	case headerName != "":
-		extractLabeler = injectproxy.HTTPHeaderEnforcer{Name: http.CanonicalHeaderKey(headerName)}
+		extractLabeler = injectproxy.HTTPHeaderEnforcer{Name: http.CanonicalHeaderKey(headerName), ParseListSyntax: headerUsesListSyntax}
 	}
 
 	var g run.Group


### PR DESCRIPTION
Currently, prom-label-proxy will accept multiple header values only if they correspond to separately-occurring header lines in the incoming HTTP request. Example request:

```
GET /api/v1/query?query=up HTTP/1.1
Host: localhost:9090
User-Agent: curl/7.68.0
X-Tenant: firsttenant
X-Tenant: secondtenant
Accept: */*
```
Attempting to pass multiple header values via list-style syntax as described in RFC 9110 (https://www.rfc-editor.org/rfc/rfc9110#name-field-lines-and-combined-fi), on the other hand, results in a single tenant value consisting of the entire comma-separated string. Example request:

```
GET /api/v1/query?query=up HTTP/1.1
Host: localhost:9090
User-Agent: curl/7.68.0
X-Tenant: firsttenant, secondtenant
Accept: */*
```
With the above sample request, the tenant label match expression becomes "firsttenant, secondtenant"

This is inconvenient for use with Custom Header configuration on Grafana Data Sources, which seem to be unable to pass more than one request header line for a given header name -- the last header value overwrites the first.

This pull request adds OPTIONAL support for parsing the tenant request header as a comma-separated list. To enable, add the parameter "-header-uses-list-syntax" to the prom-label-proxy's commandline.

When the list syntax option enabled, the sample request containing the "firsttenant, secondtenant" list given above ultimately produces the tenant label match expression "firsttenant|secondtenant".
