### PR TITLE
chore: refactor PromQL enforcer

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ prom-label-proxy \
 
 `prom-label-proxy` will enforce the `tenant=~"prometheus|alertmanager"` label selector in all requests.
 
-You can match the label value  using a regular expression with the `-regex-match` option. For example:
+You can match the label value using a regular expression with the `-regex-match` option. For example:
 
 ```
 prom-label-proxy \

--- a/main.go
+++ b/main.go
@@ -124,9 +124,11 @@ func main() {
 	if enableLabelAPIs {
 		opts = append(opts, injectproxy.WithEnabledLabelsAPI())
 	}
+
 	if len(unsafePassthroughPaths) > 0 {
 		opts = append(opts, injectproxy.WithPassthroughPaths(strings.Split(unsafePassthroughPaths, ",")))
 	}
+
 	if errorOnReplace {
 		opts = append(opts, injectproxy.WithErrorOnReplace())
 	}
@@ -136,16 +138,19 @@ func main() {
 			if len(labelValues) > 1 {
 				log.Fatalf("Regex match is limited to one label value")
 			}
+
 			compiledRegex, err := regexp.Compile(labelValues[0])
 			if err != nil {
 				log.Fatalf("Invalid regexp: %v", err.Error())
 				return
 			}
+
 			if compiledRegex.MatchString("") {
 				log.Fatalf("Regex should not match empty string")
 				return
 			}
 		}
+
 		opts = append(opts, injectproxy.WithRegexMatch())
 	}
 


### PR DESCRIPTION
This change renames the Enforcer struct to PromQLEnforcer to clarify its purpose. It also removes the error type casting in favor of error wrapping.