### PR TITLE
fix: support regex for non-query endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ NOTE: When the `/api/v1/labels` and `/api/v1/label/<name>/values` endpoints were
 
 ### Rules endpoint
 
-The proxy requests the `/api/v1/rules` Prometheus endpoint, discards the rules that don't contain an exact match of the label and returns the modified response to the client.
+The proxy requests the `/api/v1/rules` Prometheus endpoint, discards the rules that don't contain an exact match of the label(s) and returns the modified response to the client.
 
 ### Alerts endpoint
 
-The proxy requests the `/api/v1/alerts` Prometheus endpoint, discards the rules that don't contain an exact match of the label and returns the modified response to the client.
+The proxy requests the `/api/v1/alerts` Prometheus endpoint, discards the rules that don't contain an exact match of the label(s) and returns the modified response to the client.
 
 ### Silences endpoint
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/prometheus/alertmanager v0.27.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/prometheus v0.52.1
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	gotest.tools/v3 v3.5.1
 )
 


### PR DESCRIPTION
PR #171 implemented support for regex label values but only for the query endpoints. This change adds support for all other Prometheus API endpoints.

FYI @sathieu. I remember that we discussed about the issue with the Alertmanager API endpoints but nothing about the non-query Prometheus endpoints. Let me know if the change looks sane.