### PR TITLE
change: make `-error-on-replace` more cooperating

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ prom-label-proxy \
 
 > :warning: The above feature is experimental. Be careful when using this option, it may expose sensitive metrics if you use a too permissive expression.
 
-To error out when the query already contains a label matcher that differs from the one the proxy would inject, you can use the `-error-on-replace` option. For example:
+To error out when the query already contains a label matcher that conflicts with the one the proxy would inject, you can use the `-error-on-replace` option. For example:
 
 ```
 prom-label-proxy \

--- a/injectproxy/enforce.go
+++ b/injectproxy/enforce.go
@@ -152,28 +152,124 @@ func (ms PromQLEnforcer) EnforceNode(node parser.Node) error {
 	return nil
 }
 
-// EnforceMatchers appends the configured label matcher if not present.
-// If the label matcher that is to be injected is present (by labelname) but
-// different (either by match type or value) the behavior depends on the
-// errorOnReplace variable and the enforced matcher(s):
-// * if errorOnReplace is true, an error is returned,
-// * if errorOnReplace is false and the label matcher type is '=', the existing matcher is silently replaced.
-// * otherwise the existing matcher is preserved.
+// EnforceMatchers appends the enforced label matcher(s) to the list of matchers
+// if not already present.
+//
+// If the label matcher that is to be injected is present (by labelname), the
+// behavior depends on the errorOnReplace variable and the enforced matcher(s):
+// * If errorOnReplace is false
+//   - And the label matcher type is '=', the existing matcher is silently
+//     discarded whatever is the original value.
+//   - Otherwise the existing matcher is preserved.
+//
+// * if errorOnReplace is true
+//   - And the label matcher and the enforced matcher are disjoint, the function returns an error.
+//   - Otherwise the existing matcher is preserved.
 func (ms PromQLEnforcer) EnforceMatchers(targets []*labels.Matcher) ([]*labels.Matcher, error) {
 	var res []*labels.Matcher
 
 	for _, target := range targets {
-		if matcher, ok := ms.labelMatchers[target.Name]; ok {
-			// matcher.String() returns something like "labelfoo=value"
-			if ms.errorOnReplace && matcher.String() != target.String() {
-				return res, fmt.Errorf("%w: label matcher value %q conflicts with injected value %q", ErrIllegalLabelMatcher, matcher.String(), target.String())
+		matcher, ok := ms.labelMatchers[target.Name]
+		if !ok {
+			res = append(res, target)
+			continue
+		}
+
+		if ms.errorOnReplace {
+			var ok bool
+
+			// Ensure that the expression's matcher combined with the
+			// enforced matchers can return some result. If the combined
+			// matchers return no result, the function returns an error.
+			//
+			// For instance, when te enforced matcher is 'tenant="bar"':
+			// * and the expression's selector is 'tenant="foo"' then the
+			// result is always empty.
+			// * and the expression's selector is 'tenant!="foo"' then the
+			// matchers don't conflict.
+			switch matcher.Type {
+
+			case labels.MatchEqual:
+				switch target.Type {
+				case labels.MatchEqual:
+					ok = matcher.Value == target.Value
+				case labels.MatchNotEqual:
+					ok = matcher.Value != target.Value
+				case labels.MatchRegexp:
+					ok = target.Matches(matcher.Value)
+				case labels.MatchNotRegexp:
+					ok = target.Matches(matcher.Value)
+				}
+
+			case labels.MatchNotEqual:
+				switch target.Type {
+				case labels.MatchEqual:
+					ok = target.Value == "" || matcher.Matches(target.Value)
+				case labels.MatchNotEqual:
+					ok = true
+				case labels.MatchRegexp:
+					frm, _ := labels.NewFastRegexMatcher(target.Value)
+					ok = (frm == nil || len(frm.SetMatches()) == 0)
+					if !ok {
+						for _, sm := range frm.SetMatches() {
+							if sm != matcher.Value {
+								ok = true
+								break
+							}
+						}
+					}
+				case labels.MatchNotRegexp:
+					ok = true
+				}
+
+			case labels.MatchRegexp:
+				switch target.Type {
+				case labels.MatchEqual:
+					ok = matcher.Matches(target.Value)
+				case labels.MatchNotEqual:
+					ok = true
+				case labels.MatchRegexp:
+					ok = target.Value != ""
+				case labels.MatchNotRegexp:
+					ok = target.Value != matcher.Value
+				}
+
+			case labels.MatchNotRegexp:
+				switch target.Type {
+				case labels.MatchEqual:
+					ok = target.Value != "" || !matcher.Matches("")
+				case labels.MatchNotEqual:
+					ok = true
+				case labels.MatchRegexp:
+					frm, _ := labels.NewFastRegexMatcher(target.Value)
+					if frm != nil {
+						for _, sm := range frm.SetMatches() {
+							if matcher.Matches(sm) {
+								ok = true
+								break
+							}
+						}
+					}
+					ok = ok && !(target.Value == "" && matcher.Matches(""))
+					ok = ok && target.Value != matcher.Value
+				case labels.MatchNotRegexp:
+					ok = true
+				}
 			}
 
-			// Drop the existing matcher only if the enforced matcher is an
-			// equal matcher.
-			if matcher.Type == labels.MatchEqual {
-				continue
+			if !ok {
+				return res, fmt.Errorf("%w: label matcher %q conflicts with injected matcher %q", ErrIllegalLabelMatcher, target.String(), matcher.String())
 			}
+		}
+
+		// Always drop the expression matcher if:
+		// * the enforced matcher is an equal matcher because it will be
+		// added after iterating on all the expression's matchers.
+		// * or it is equal to the enforced matcher.
+		// In both cases, the enforced matcher will be added after
+		// iterating on all the expression's matchers.
+		if matcher.Type == labels.MatchEqual || matcher.String() == target.String() {
+			continue
 		}
 
 		res = append(res, target)

--- a/injectproxy/enforce_test.go
+++ b/injectproxy/enforce_test.go
@@ -21,6 +21,15 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
+func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
+	m, err := labels.NewMatcher(t, n, v)
+	if err != nil {
+		panic(err)
+	}
+
+	return m
+}
+
 type checkFunc func(expression string, err error) error
 
 func checks(cs ...checkFunc) checkFunc {
@@ -353,6 +362,536 @@ func TestEnforce(t *testing.T) {
 			got, err := tc.enforcer.Enforce(tc.expression)
 			if err := tc.check(got, err); err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEnforceWithErrOnReplace(t *testing.T) {
+	type subTestCase struct {
+		labelSelector string
+		exp           string
+		err           bool
+	}
+
+	for _, tc := range []struct {
+		enforcedMatcher *labels.Matcher
+		stcs            []subTestCase
+	}{
+		// Equal matcher enforcer.
+		{
+			enforcedMatcher: mustNewMatcher(labels.MatchEqual, "job", "foo"),
+			stcs: []subTestCase{
+				// No selector in the expression for the enforced label.
+				{
+					``,
+					`up{job="foo"}`,
+					false,
+				},
+
+				// Equal label selector in the expression.
+				{
+					`job=""`,
+					``,
+					true,
+				},
+				{
+					`job="foo"`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job="bar"`,
+					``,
+					true,
+				},
+				{
+					`job="fred"`,
+					``,
+					true,
+				},
+
+				// Not equal label selector in the expression.
+				{
+					`job!=""`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job!="foo"`,
+					``,
+					true,
+				},
+				{
+					`job!="bar"`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job!="fred"`,
+					`up{job="foo"}`,
+					false,
+				},
+
+				// Regexp label selector in the expression.
+				{
+					`job=~""`,
+					``,
+					true,
+				},
+				{
+					`job=~"foo"`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job=~"bar"`,
+					``,
+					true,
+				},
+				{
+					`job=~"fred"`,
+					``,
+					true,
+				},
+				{
+					`job=~"foo|fred"`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job=~"foo|bar"`,
+					`up{job="foo"}`,
+					false,
+				},
+
+				// Not-regexp label selector in the expression.
+				{
+					`job!~""`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job!~"foo"`,
+					``,
+					true,
+				},
+				{
+					`job!~"bar"`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job!~"fred"`,
+					`up{job="foo"}`,
+					false,
+				},
+				{
+					`job!~"foo|fred"`,
+					``,
+					true,
+				},
+				{
+					`job!~"foo|bar"`,
+					``,
+					true,
+				},
+			},
+		},
+
+		// Not equal matcher enforcer.
+		{
+			enforcedMatcher: mustNewMatcher(labels.MatchNotEqual, "job", "foo"),
+			stcs: []subTestCase{
+				// No selector in the expression for the enforced label.
+				{
+					``,
+					`up{job!="foo"}`,
+					false,
+				},
+
+				// Equal label selector in the expression.
+				{
+					`job=""`,
+					`up{job!="foo",job=""}`,
+					false,
+				},
+				{
+					`job="foo"`,
+					``,
+					true,
+				},
+				{
+					`job="bar"`,
+					`up{job!="foo",job="bar"}`,
+					false,
+				},
+				{
+					`job="fred"`,
+					`up{job!="foo",job="fred"}`,
+					false,
+				},
+
+				// Not equal label selector in the expression.
+				{
+					`job!=""`,
+					`up{job!="",job!="foo"}`,
+					false,
+				},
+				{
+					`job!="foo"`,
+					`up{job!="foo"}`,
+					false,
+				},
+				{
+					`job!="bar"`,
+					`up{job!="bar",job!="foo"}`,
+					false,
+				},
+				{
+					`job!="fred"`,
+					`up{job!="foo",job!="fred"}`,
+					false,
+				},
+
+				// Regexp label selector in the expression.
+				{
+					`job=~""`,
+					`up{job!="foo",job=~""}`,
+					false,
+				},
+				{
+					// up{job!="foo",job=~"foo"} would return no result.
+					`job=~"foo"`,
+					``,
+					true,
+				},
+				{
+					`job=~"bar"`,
+					`up{job!="foo",job=~"bar"}`,
+					false,
+				},
+				{
+					`job=~"fred"`,
+					`up{job!="foo",job=~"fred"}`,
+					false,
+				},
+				{
+					`job=~"foo|fred"`,
+					`up{job!="foo",job=~"foo|fred"}`,
+					false,
+				},
+				{
+					`job=~"foo|bar"`,
+					`up{job!="foo",job=~"foo|bar"}`,
+					false,
+				},
+
+				// Not-regexp label selector in the expression.
+				{
+					`job!~""`,
+					`up{job!="foo",job!~""}`,
+					false,
+				},
+				{
+					`job!~"foo"`,
+					`up{job!="foo",job!~"foo"}`,
+					false,
+				},
+				{
+					`job!~"bar"`,
+					`up{job!="foo",job!~"bar"}`,
+					false,
+				},
+				{
+					`job!~"fred"`,
+					`up{job!="foo",job!~"fred"}`,
+					false,
+				},
+				{
+					`job!~"foo|fred"`,
+					`up{job!="foo",job!~"foo|fred"}`,
+					false,
+				},
+				{
+					`job!~"foo|bar"`,
+					`up{job!="foo",job!~"foo|bar"}`,
+					false,
+				},
+			},
+		},
+
+		// Regexp matcher enforcer.
+		{
+			enforcedMatcher: mustNewMatcher(labels.MatchRegexp, "job", "foo|bar"),
+			stcs: []subTestCase{
+				// No selector in the expression for the enforced label.
+				{
+					``,
+					`up{job=~"foo|bar"}`,
+					false,
+				},
+
+				// Equal label selector in the expression.
+				{
+					`job=""`,
+					``,
+					true,
+				},
+				{
+					`job="foo"`,
+					`up{job="foo",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job="bar"`,
+					`up{job="bar",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job="fred"`,
+					``,
+					true,
+				},
+
+				// Not equal label selector in the expression.
+				{
+					`job!=""`,
+					`up{job!="",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!="foo"`,
+					`up{job!="foo",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!="bar"`,
+					`up{job!="bar",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!="fred"`,
+					`up{job!="fred",job=~"foo|bar"}`,
+					false,
+				},
+
+				// Regexp label selector in the expression.
+				{
+					`job=~""`,
+					``,
+					true,
+				},
+				{
+					`job=~"foo"`,
+					`up{job=~"foo",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job=~"bar"`,
+					`up{job=~"bar",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job=~"fred"`,
+					`up{job=~"foo|bar",job=~"fred"}`,
+					false,
+				},
+				{
+					`job=~"foo|fred"`,
+					`up{job=~"foo|bar",job=~"foo|fred"}`,
+					false,
+				},
+				{
+					`job=~"foo|bar"`,
+					`up{job=~"foo|bar"}`,
+					false,
+				},
+
+				// Not-regexp label selector in the expression.
+				{
+					`job!~""`,
+					`up{job!~"",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"foo"`,
+					`up{job!~"foo",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"bar"`,
+					`up{job!~"bar",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"fred"`,
+					`up{job!~"fred",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"foo|fred"`,
+					`up{job!~"foo|fred",job=~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"foo|bar"`,
+					``,
+					true,
+				},
+			},
+		},
+
+		// Not regexp matcher enforcer.
+		{
+			enforcedMatcher: mustNewMatcher(labels.MatchNotRegexp, "job", "foo|bar"),
+			stcs: []subTestCase{
+				// No selector in the expression for the enforced label.
+				{
+					``,
+					`up{job!~"foo|bar"}`,
+					false,
+				},
+
+				// Equal label selector in the expression.
+				{
+					`job=""`,
+					``,
+					true,
+				},
+				{
+					`job="foo"`,
+					`up{job!~"foo|bar",job="foo"}`,
+					false,
+				},
+				{
+					`job="bar"`,
+					`up{job!~"foo|bar",job="bar"}`,
+					false,
+				},
+				{
+					`job="fred"`,
+					`up{job!~"foo|bar",job="fred"}`,
+					false,
+				},
+
+				// Not equal label selector in the expression.
+				{
+					`job!=""`,
+					`up{job!="",job!~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!="foo"`,
+					`up{job!="foo",job!~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!="bar"`,
+					`up{job!="bar",job!~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!="fred"`,
+					`up{job!="fred",job!~"foo|bar"}`,
+					false,
+				},
+
+				// Regexp label selector in the expression.
+				{
+					`job=~""`,
+					``,
+					true,
+				},
+				{
+					// up{job!~"foo|bar",job=~"foo"} would return no result.
+					`job=~"foo"`,
+					``,
+					true,
+				},
+				{
+					// up{job!~"foo|bar",job=~"bar"} would return no result.
+					`job=~"bar"`,
+					``,
+					true,
+				},
+				{
+					`job=~"fred"`,
+					`up{job!~"foo|bar",job=~"fred"}`,
+					false,
+				},
+				{
+					`job=~"foo|fred"`,
+					`up{job!~"foo|bar",job=~"foo|fred"}`,
+					false,
+				},
+				{
+					`job=~"foo|bar"`,
+					``,
+					true,
+				},
+
+				// Not-regexp label selector in the expression.
+				{
+					`job!~""`,
+					`up{job!~"",job!~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"foo"`,
+					`up{job!~"foo",job!~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"bar"`,
+					`up{job!~"bar",job!~"foo|bar"}`,
+					false,
+				},
+				{
+					`job!~"fred"`,
+					`up{job!~"foo|bar",job!~"fred"}`,
+					false,
+				},
+				{
+					`job!~"foo|fred"`,
+					`up{job!~"foo|bar",job!~"foo|fred"}`,
+					false,
+				},
+				{
+					`job!~"foo|bar"`,
+					`up{job!~"foo|bar"}`,
+					false,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("enforcer=%q", tc.enforcedMatcher.String()), func(t *testing.T) {
+			enforcer := NewPromQLEnforcer(true, tc.enforcedMatcher)
+
+			for _, stc := range tc.stcs {
+				expr := fmt.Sprintf("up{%s}", stc.labelSelector)
+				t.Run(expr, func(t *testing.T) {
+					got, err := enforcer.Enforce(expr)
+					if stc.err {
+						if err == nil {
+							t.Fatalf("expected error, got nil")
+						}
+
+						if !errors.Is(err, ErrIllegalLabelMatcher) {
+							t.Fatalf("expected err,ErrIllegalLabelMatcher error, got %s", err)
+						}
+
+						return
+					}
+
+					if err != nil {
+						t.Fatalf("expected no error, got %s", err.Error())
+					}
+
+					if got != stc.exp {
+						t.Fatalf("expected expression %q, got %q", stc.exp, got)
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
With this change, the proxy wouldn't necessary return an error if `-error-on-replace` is set and the incoming query has a label matcher overlapping with the enforced label.

For instance when the enforced label is `namespace="foo"`, the following expressions aren't rejected anymore:
- `up{namespace!="bar"}`
- `up{namespace=~"foo|bar"}`
- `up{namespace!~"bar"}`

The following expressions are rejected as before:
- `up{namespace=""}`
- `up{namespace="bar"}`
- `up{namespace=~"bar|fred"}`
- `up{namespace!~"foo"}`