### PR TITLE
Add bypass logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/alertmanager v0.28.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/prometheus v0.304.1
+	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	gotest.tools/v3 v3.5.2
 )
 

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 		regexMatch             bool
 		headerUsesListSyntax   bool
 		rulesWithActiveAlerts  bool
+		bypassQueries          arrayFlags
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -88,6 +89,7 @@ func main() {
 	flagset.BoolVar(&regexMatch, "regex-match", false, "When specified, the tenant name is treated as a regular expression. In this case, only one tenant name should be provided.")
 	flagset.BoolVar(&headerUsesListSyntax, "header-uses-list-syntax", false, "When specified, the header line value will be parsed as a comma-separated list. This allows a single tenant header line to specify multiple tenant names.")
 	flagset.BoolVar(&rulesWithActiveAlerts, "rules-with-active-alerts", false, "When true, the proxy will return alerting rules with active alerts matching the tenant label even when the tenant label isn't present in the rule's labels.")
+	flagset.Var(&bypassQueries, "bypass-query", "A query to bypass the proxy. This can be a PromQL query or a label selector. It can be repeated in which case the proxy will bypass all matching queries.")
 
 	//nolint: errcheck // Parse() will exit on error.
 	flagset.Parse(os.Args[1:])
@@ -158,6 +160,10 @@ func main() {
 		}
 
 		opts = append(opts, injectproxy.WithRegexMatch())
+	}
+
+	if len(bypassQueries) > 0 {
+		opts = append(opts, injectproxy.WithBypassQueries(bypassQueries))
 	}
 
 	var extractLabeler injectproxy.ExtractLabeler


### PR DESCRIPTION
Hi!

First of all: Thanks for this project! 🙂 
We experienced an issue with setting up prom-label-proxy in front of a thanos stack when just checking for the existence of a label without setting one. Specifically Grafana sends `1+1` as a query to test if the endpoint works. Currently, this will fail as the enforced label is missing.

To circumvent this I've implemented a `BypassHandler` which accepts queries via a new `--bypass-query` flag. If this query is found in the request the whole enforcement chain is skipped and request is directly send to the proxied endpoint.

Happy to hear your feedback!