### PR TITLE
feat: implement more PromQL options

### DIFF
--- a/injectproxy/enforce_test.go
+++ b/injectproxy/enforce_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
 func mustNewMatcher(t labels.MatchType, n, v string) *labels.Matcher {
@@ -990,6 +991,92 @@ func TestEnforceWithErrOnReplace(t *testing.T) {
 						t.Fatalf("expected expression %q, got %q", stc.exp, got)
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestEnforceWithParserOptions(t *testing.T) {
+	ns := mustNewMatcher(labels.MatchEqual, "namespace", "NS")
+
+	for _, tc := range []struct {
+		name       string
+		expression string
+		enforcer   *PromQLEnforcer
+		check      checkFunc
+	}{
+		// EnableExperimentalFunctions
+		{
+			name:       "experimental function enabled",
+			expression: `mad_over_time(metric[5m])`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{EnableExperimentalFunctions: true}, ns),
+			check: checks(
+				noError(),
+				hasExpression(`mad_over_time(metric{namespace="NS"}[5m])`),
+			),
+		},
+		{
+			name:       "experimental function disabled",
+			expression: `mad_over_time(metric[5m])`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{}, ns),
+			check:      errorIs(ErrQueryParse),
+		},
+
+		// ExperimentalDurationExpr
+		{
+			name:       "experimental duration expression enabled",
+			expression: `rate(metric[5m * 2])`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{ExperimentalDurationExpr: true}, ns),
+			check: checks(
+				noError(),
+				hasExpression(`rate(metric{namespace="NS"}[5m * 2])`),
+			),
+		},
+		{
+			name:       "experimental duration expression disabled",
+			expression: `rate(metric[5m * 2])`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{}, ns),
+			check:      errorIs(ErrQueryParse),
+		},
+
+		// EnableExtendedRangeSelectors
+		{
+			name:       "extended range selectors enabled",
+			expression: `metric anchored`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{EnableExtendedRangeSelectors: true}, ns),
+			check: checks(
+				noError(),
+				hasExpression(`metric{namespace="NS"} anchored`),
+			),
+		},
+		{
+			name:       "extended range selectors disabled",
+			expression: `metric anchored`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{}, ns),
+			check:      errorIs(ErrQueryParse),
+		},
+
+		// EnableBinopFillModifiers
+		{
+			name:       "binop fill modifiers enabled",
+			expression: `metric_a + fill(0) metric_b`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{EnableBinopFillModifiers: true}, ns),
+			check: checks(
+				noError(),
+				hasExpression(`metric_a{namespace="NS"} + fill (0) metric_b{namespace="NS"}`),
+			),
+		},
+		{
+			name:       "binop fill modifiers disabled",
+			expression: `metric_a + fill(0) metric_b`,
+			enforcer:   NewPromQLEnforcerWithOptions(false, parser.Options{}, ns),
+			check:      errorIs(ErrQueryParse),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.enforcer.Enforce(tc.expression)
+			if err := tc.check(got, err); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -162,6 +162,13 @@ func WithPromqlExperimentalFunctions() Option {
 	})
 }
 
+// WithPromqlExtendedRangeSelectors enables extended range selectors in the PromQL parser.
+func WithPromqlExtendedRangeSelectors() Option {
+	return optionFunc(func(o *options) {
+		o.parserOptions.EnableExtendedRangeSelectors = true
+	})
+}
+
 // mux abstracts away the behavior we expect from the http.ServeMux type in this package.
 type mux interface {
 	http.Handler

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -169,6 +169,13 @@ func WithPromqlExtendedRangeSelectors() Option {
 	})
 }
 
+// WithPromqlBinopFillModifiers enables binary operation fill modifiers in the PromQL parser.
+func WithPromqlBinopFillModifiers() Option {
+	return optionFunc(func(o *options) {
+		o.parserOptions.EnableBinopFillModifiers = true
+	})
+}
+
 // mux abstracts away the behavior we expect from the http.ServeMux type in this package.
 type mux interface {
 	http.Handler

--- a/main.go
+++ b/main.go
@@ -71,8 +71,9 @@ func main() {
 		headerUsesListSyntax            bool
 		rulesWithActiveAlerts           bool
 		labelMatchersForRulesAPI        bool
-		promQLDurationExpressionParsing bool
-		promQLExperimentalFunctions     bool
+		promQLDurationExpressionParsing  bool
+		promQLExperimentalFunctions      bool
+		promQLExtendedRangeSelectors     bool
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -98,6 +99,7 @@ func main() {
 	flagset.BoolVar(&labelMatchersForRulesAPI, "enable-label-matchers-for-rules-api", false, "When true, the proxy uses label matchers when querying the /api/v1/rules endpoint. NOTE: Enable with care because filtering by label matcher is not implemented in older versions of Prometheus (>= 2.54.0 required) and Thanos (>= v0.25.0 required). If not implemented by upstream, the response will not be filtered accordingly.")
 	flagset.BoolVar(&promQLDurationExpressionParsing, "enable-promql-duration-expression-parsing", false, "When true, the proxy supports arithmetic for durations in PromQL expressions.")
 	flagset.BoolVar(&promQLExperimentalFunctions, "enable-promql-experimental-functions", false, "When true, the proxy supports experimental functions in PromQL expressions.")
+	flagset.BoolVar(&promQLExtendedRangeSelectors, "enable-promql-extended-range-selectors", false, "When true, the proxy supports extended range selectors in PromQL expressions.")
 
 	//nolint: errcheck // Parse() will exit on error.
 	flagset.Parse(os.Args[1:])
@@ -188,6 +190,10 @@ func main() {
 
 	if promQLExperimentalFunctions {
 		opts = append(opts, injectproxy.WithPromqlExperimentalFunctions())
+	}
+
+	if promQLExtendedRangeSelectors {
+		opts = append(opts, injectproxy.WithPromqlExtendedRangeSelectors())
 	}
 
 	var extractLabeler injectproxy.ExtractLabeler

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		promQLDurationExpressionParsing  bool
 		promQLExperimentalFunctions      bool
 		promQLExtendedRangeSelectors     bool
+		promQLBinopFillModifiers         bool
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -100,6 +101,7 @@ func main() {
 	flagset.BoolVar(&promQLDurationExpressionParsing, "enable-promql-duration-expression-parsing", false, "When true, the proxy supports arithmetic for durations in PromQL expressions.")
 	flagset.BoolVar(&promQLExperimentalFunctions, "enable-promql-experimental-functions", false, "When true, the proxy supports experimental functions in PromQL expressions.")
 	flagset.BoolVar(&promQLExtendedRangeSelectors, "enable-promql-extended-range-selectors", false, "When true, the proxy supports extended range selectors in PromQL expressions.")
+	flagset.BoolVar(&promQLBinopFillModifiers, "enable-promql-binop-fill-modifiers", false, "When true, the proxy supports binary operation fill modifiers in PromQL expressions.")
 
 	//nolint: errcheck // Parse() will exit on error.
 	flagset.Parse(os.Args[1:])
@@ -194,6 +196,10 @@ func main() {
 
 	if promQLExtendedRangeSelectors {
 		opts = append(opts, injectproxy.WithPromqlExtendedRangeSelectors())
+	}
+
+	if promQLBinopFillModifiers {
+		opts = append(opts, injectproxy.WithPromqlBinopFillModifiers())
 	}
 
 	var extractLabeler injectproxy.ExtractLabeler

--- a/main.go
+++ b/main.go
@@ -71,10 +71,10 @@ func main() {
 		headerUsesListSyntax            bool
 		rulesWithActiveAlerts           bool
 		labelMatchersForRulesAPI        bool
-		promQLDurationExpressionParsing  bool
-		promQLExperimentalFunctions      bool
-		promQLExtendedRangeSelectors     bool
-		promQLBinopFillModifiers         bool
+		promQLDurationExpressionParsing bool
+		promQLExperimentalFunctions     bool
+		promQLExtendedRangeSelectors    bool
+		promQLBinopFillModifiers        bool
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)


### PR DESCRIPTION
This PR adds the following CLI arguments to cover the 2 remaining PromQL options not currently supported:
* `--enable-promql-binop-fill-modifiers`
* `--enable-promql-extended-range-selectors`