### PR TITLE
ci: migrate publish_release job to github.token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
   publish_release:
     name: Publish release artefacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [test_go, build]
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
@@ -66,4 +68,4 @@ jobs:
           docker_hub_password: ${{ secrets.docker_hub_password }}
           quay_io_organization: prometheuscommunity
           quay_io_password: ${{ secrets.quay_io_password }}
-          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
+          github_token: ${{ github.token }}


### PR DESCRIPTION
Replace PROMBOT_GITHUB_TOKEN secret with the built-in github.token and add the required permissions block (contents: write) to the job.