### PR TITLE
Support client cert/key and server name for upstream TLS

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -507,7 +507,7 @@ func NewRoutes(upstream *url.URL, label string, extractLabeler ExtractLabeler, o
 
 		cert, err := tls.LoadX509KeyPair(opt.upstreamClientCertFile, opt.upstreamClientKeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate/key pair: %v", err)
+			return nil, fmt.Errorf("failed to load client certificate/key pair: %w", err)
 		}
 
 		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -61,6 +61,9 @@ type routes struct {
 
 type options struct {
 	upstreamCaCert           string
+	upstreamClientCertFile   string
+	upstreamClientKeyFile    string
+	upstreamServerName       string
 	enableLabelAPIs          bool
 	passthroughPaths         []string
 	insecureSkipVerify       bool
@@ -93,6 +96,23 @@ func WithPrometheusRegistry(reg prometheus.Registerer) Option {
 func WithUpstreamCaCert(caCert string) Option {
 	return optionFunc(func(o *options) {
 		o.upstreamCaCert = caCert
+	})
+}
+
+// WithUpstreamClientCert configures the proxy to present the given client
+// certificate and key for mutual TLS with the upstream.
+func WithUpstreamClientCert(certFile, keyFile string) Option {
+	return optionFunc(func(o *options) {
+		o.upstreamClientCertFile = certFile
+		o.upstreamClientKeyFile = keyFile
+	})
+}
+
+// WithUpstreamServerName configures the server name used to verify the
+// upstream's TLS certificate (also used as the SNI server name).
+func WithUpstreamServerName(name string) Option {
+	return optionFunc(func(o *options) {
+		o.upstreamServerName = name
 	})
 }
 
@@ -463,6 +483,7 @@ func NewRoutes(upstream *url.URL, label string, extractLabeler ExtractLabeler, o
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: opt.insecureSkipVerify,
+		ServerName:         opt.upstreamServerName,
 	}
 
 	if opt.upstreamCaCert != "" {
@@ -477,6 +498,19 @@ func NewRoutes(upstream *url.URL, label string, extractLabeler ExtractLabeler, o
 		}
 
 		transport.TLSClientConfig.RootCAs = caCertPool
+	}
+
+	if opt.upstreamClientCertFile != "" || opt.upstreamClientKeyFile != "" {
+		if opt.upstreamClientCertFile == "" || opt.upstreamClientKeyFile == "" {
+			return nil, fmt.Errorf("both client certificate and key files must be provided")
+		}
+
+		cert, err := tls.LoadX509KeyPair(opt.upstreamClientCertFile, opt.upstreamClientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate/key pair: %v", err)
+		}
+
+		transport.TLSClientConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	proxy.Transport = transport

--- a/injectproxy/routes_tls_test.go
+++ b/injectproxy/routes_tls_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/injectproxy/routes_tls_test.go
+++ b/injectproxy/routes_tls_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package injectproxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCertKey generates a self-signed certificate and key and writes them
+// to temporary PEM files, returning their paths.
+func writeTestCertKey(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("failed to write cert: %v", err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}), 0o600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+	return certFile, keyFile
+}
+
+func transportTLSConfig(t *testing.T, r *routes) *tls.Config {
+	t.Helper()
+	proxy, ok := r.handler.(*httputil.ReverseProxy)
+	if !ok {
+		t.Fatalf("handler is not a *httputil.ReverseProxy, got %T", r.handler)
+	}
+	transport, ok := proxy.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is not a *http.Transport, got %T", proxy.Transport)
+	}
+	return transport.TLSClientConfig
+}
+
+func TestNewRoutesUpstreamTLSConfig(t *testing.T) {
+	certFile, keyFile := writeTestCertKey(t)
+	upstream, _ := url.Parse("https://upstream.example")
+
+	r, err := NewRoutes(upstream, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel},
+		WithUpstreamClientCert(certFile, keyFile),
+		WithUpstreamServerName("custom.example"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg := transportTLSConfig(t, r)
+	if cfg.ServerName != "custom.example" {
+		t.Errorf("ServerName = %q, want %q", cfg.ServerName, "custom.example")
+	}
+	if got := len(cfg.Certificates); got != 1 {
+		t.Errorf("len(Certificates) = %d, want 1", got)
+	}
+}
+
+func TestNewRoutesUpstreamClientCertErrors(t *testing.T) {
+	certFile, keyFile := writeTestCertKey(t)
+	upstream, _ := url.Parse("https://upstream.example")
+
+	for name, opt := range map[string]Option{
+		"only cert provided": WithUpstreamClientCert(certFile, ""),
+		"only key provided":  WithUpstreamClientCert("", keyFile),
+		"nonexistent files":  WithUpstreamClientCert("/does/not/exist.crt", "/does/not/exist.key"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewRoutes(upstream, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, opt); err == nil {
+				t.Error("expected an error, got nil")
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 		internalListenAddress           string
 		upstream                        string
 		upstreamCaCert                  string
+		upstreamClientCert              string
+		upstreamClientKey               string
+		upstreamServerName              string
 		queryParam                      string
 		headerName                      string
 		label                           string
@@ -84,6 +87,9 @@ func main() {
 	flagset.StringVar(&headerName, "header-name", "", "Name of the HTTP header name that contains the tenant value. At most one of -query-param, -header-name and -label-value should be given.")
 	flagset.StringVar(&upstream, "upstream", "", "The upstream URL to proxy to.")
 	flagset.StringVar(&upstreamCaCert, "upstream-ca-cert", "", "The upstream ca certificate file.")
+	flagset.StringVar(&upstreamClientCert, "upstream-client-cert", "", "The client certificate file to present for mutual TLS with the upstream. Requires -upstream-client-key.")
+	flagset.StringVar(&upstreamClientKey, "upstream-client-key", "", "The client key file to present for mutual TLS with the upstream. Requires -upstream-client-cert.")
+	flagset.StringVar(&upstreamServerName, "upstream-server-name", "", "The server name used to verify the upstream's TLS certificate. Useful when the upstream URL host does not match the certificate.")
 	flagset.StringVar(&label, "label", "", "The label name to enforce in all proxied PromQL queries.")
 	flagset.Var(&labelValues, "label-value", "A fixed label value to enforce in all proxied PromQL queries. At most one of -query-param, -header-name and -label-value should be given. It can be repeated in which case the proxy will enforce the union of values.")
 	flagset.BoolVar(&enableLabelAPIs, "enable-label-apis", false, "When specified proxy allows to inject label to label APIs like /api/v1/labels and /api/v1/label/<name>/values. "+
@@ -136,9 +142,21 @@ func main() {
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
+	if (upstreamClientCert == "") != (upstreamClientKey == "") {
+		log.Fatalf("both -upstream-client-cert and -upstream-client-key must be set")
+	}
+
 	opts := []injectproxy.Option{injectproxy.WithPrometheusRegistry(reg)}
 	if upstreamCaCert != "" {
 		opts = append(opts, injectproxy.WithUpstreamCaCert(upstreamCaCert))
+	}
+
+	if upstreamClientCert != "" {
+		opts = append(opts, injectproxy.WithUpstreamClientCert(upstreamClientCert, upstreamClientKey))
+	}
+
+	if upstreamServerName != "" {
+		opts = append(opts, injectproxy.WithUpstreamServerName(upstreamServerName))
 	}
 
 	if enableLabelAPIs {


### PR DESCRIPTION
## Support client cert/key and server name for upstream TLS

Fixes #136.

The proxy already supported a custom CA (`-upstream-ca-cert`) and skipping verification (`-insecure-skip-verify`) for the upstream, but not the rest of the usual TLS client settings. As noted in #136, client certificate/key (mutual TLS) and an explicit TLS server name were missing.

This adds:

- `-upstream-client-cert` and `-upstream-client-key`: present a client certificate for mutual TLS with the upstream. Both must be set together.
- `-upstream-server-name`: the server name used to verify the upstream's certificate (also used for SNI), useful when the upstream URL host does not match the certificate.

Matching `injectproxy` options `WithUpstreamClientCert(certFile, keyFile)` and `WithUpstreamServerName(name)` are added alongside the existing `WithUpstreamCaCert` / `WithInsecureSkipVerify`.

### Tests

There were no existing tests for the upstream TLS configuration, so this adds `injectproxy/routes_tls_test.go`:

- verifies the client certificate is loaded and the server name is set on the proxy transport's `tls.Config`;
- verifies the error cases: only one of cert/key provided, and unreadable cert/key files.

`go test ./...`, `go vet ./...` and `gofmt` are clean.
