### PR TITLE
feat: Add --rewrite-host-header-to option for upstream requests

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -392,10 +392,9 @@ func NewRoutes(upstream *url.URL, label string, extractLabeler ExtractLabeler, o
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(upstream)
 			r.SetXForwarded()
+			r.Out.Host = r.In.Host
 			if opt.rewriteHostHeader != "" {
 				r.Out.Host = opt.rewriteHostHeader
-			} else {
-				r.Out.Host = r.In.Host
 			}
 		},
 	}

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -73,6 +73,7 @@ type options struct {
 	rulesWithActiveAlerts    bool
 	labelMatchersForRulesAPI bool
 	parserOptions            parser.Options
+	rewriteHostHeader        string
 }
 
 type Option interface {
@@ -193,6 +194,15 @@ func WithPromqlExtendedRangeSelectors() Option {
 func WithPromqlBinopFillModifiers() Option {
 	return optionFunc(func(o *options) {
 		o.parserOptions.EnableBinopFillModifiers = true
+	})
+}
+
+// WithRewriteHostHeader configures the proxy to rewrite the Host header
+// to the given value when proxying requests to the upstream. This is useful
+// when the upstream is behind an ingress that routes based on the Host header.
+func WithRewriteHostHeader(host string) Option {
+	return optionFunc(func(o *options) {
+		o.rewriteHostHeader = host
 	})
 }
 
@@ -378,7 +388,17 @@ func NewRoutes(upstream *url.URL, label string, extractLabeler ExtractLabeler, o
 		opt.registerer = prometheus.NewRegistry()
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(upstream)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(upstream)
+			r.SetXForwarded()
+			if opt.rewriteHostHeader != "" {
+				r.Out.Host = opt.rewriteHostHeader
+			} else {
+				r.Out.Host = r.In.Host
+			}
+		},
+	}
 
 	r := &routes{
 		upstream:              upstream,

--- a/injectproxy/routes_host_test.go
+++ b/injectproxy/routes_host_test.go
@@ -1,0 +1,85 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package injectproxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRewriteHostHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		rewriteHost string
+		wantHost    string
+	}{
+		{
+			name:        "host header rewritten when option is set",
+			rewriteHost: "custom.upstream.example.com",
+			wantHost:    "custom.upstream.example.com",
+		},
+		{
+			name:        "original host preserved when option is not set",
+			rewriteHost: "",
+			wantHost:    "example.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedHost, receivedXForwardedFor, receivedXForwardedHost, receivedXForwardedProto string
+			m := newMockUpstream(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				receivedHost = req.Host
+				receivedXForwardedFor = req.Header.Get("X-Forwarded-For")
+				receivedXForwardedHost = req.Header.Get("X-Forwarded-Host")
+				receivedXForwardedProto = req.Header.Get("X-Forwarded-Proto")
+				w.Write(okResponse)
+			}))
+			defer m.Close()
+
+			var opts []Option
+			if tc.rewriteHost != "" {
+				opts = append(opts, WithRewriteHostHeader(tc.rewriteHost))
+			}
+
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, opts...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "http://example.com/api/v1/query?query=up&namespace=test", nil)
+			r.ServeHTTP(w, req)
+
+			resp := w.Result()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected status code 200, got %d", resp.StatusCode)
+			}
+
+			if receivedHost != tc.wantHost {
+				t.Errorf("Host: got %q, want %q", receivedHost, tc.wantHost)
+			}
+
+			// Verify X-Forwarded-* headers are set by SetXForwarded().
+			if receivedXForwardedFor == "" {
+				t.Error("X-Forwarded-For header not set on upstream request")
+			}
+			if receivedXForwardedHost != "example.com" {
+				t.Errorf("X-Forwarded-Host: got %q, want %q", receivedXForwardedHost, "example.com")
+			}
+			if receivedXForwardedProto != "http" {
+				t.Errorf("X-Forwarded-Proto: got %q, want %q", receivedXForwardedProto, "http")
+			}
+		})
+	}
+}

--- a/injectproxy/routes_host_test.go
+++ b/injectproxy/routes_host_test.go
@@ -14,6 +14,8 @@
 package injectproxy
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,12 +39,23 @@ func TestRewriteHostHeader(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var receivedHost, receivedXForwardedFor, receivedXForwardedHost, receivedXForwardedProto string
 			m := newMockUpstream(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				receivedHost = req.Host
-				receivedXForwardedFor = req.Header.Get("X-Forwarded-For")
-				receivedXForwardedHost = req.Header.Get("X-Forwarded-Host")
-				receivedXForwardedProto = req.Header.Get("X-Forwarded-Proto")
+				if req.Host != tc.wantHost {
+					prometheusAPIError(w, fmt.Sprintf("unexpected Host: got %q, want %q", req.Host, tc.wantHost), http.StatusBadRequest)
+					return
+				}
+				if req.Header.Get("X-Forwarded-For") == "" {
+					prometheusAPIError(w, "X-Forwarded-For not set", http.StatusBadRequest)
+					return
+				}
+				if got := req.Header.Get("X-Forwarded-Host"); got != "example.com" {
+					prometheusAPIError(w, fmt.Sprintf("unexpected X-Forwarded-Host: got %q, want %q", got, "example.com"), http.StatusBadRequest)
+					return
+				}
+				if got := req.Header.Get("X-Forwarded-Proto"); got != "http" {
+					prometheusAPIError(w, fmt.Sprintf("unexpected X-Forwarded-Proto: got %q, want %q", got, "http"), http.StatusBadRequest)
+					return
+				}
 				w.Write(okResponse)
 			}))
 			defer m.Close()
@@ -63,22 +76,8 @@ func TestRewriteHostHeader(t *testing.T) {
 
 			resp := w.Result()
 			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status code 200, got %d", resp.StatusCode)
-			}
-
-			if receivedHost != tc.wantHost {
-				t.Errorf("Host: got %q, want %q", receivedHost, tc.wantHost)
-			}
-
-			// Verify X-Forwarded-* headers are set by SetXForwarded().
-			if receivedXForwardedFor == "" {
-				t.Error("X-Forwarded-For header not set on upstream request")
-			}
-			if receivedXForwardedHost != "example.com" {
-				t.Errorf("X-Forwarded-Host: got %q, want %q", receivedXForwardedHost, "example.com")
-			}
-			if receivedXForwardedProto != "http" {
-				t.Errorf("X-Forwarded-Proto: got %q, want %q", receivedXForwardedProto, "http")
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("unexpected status %d: %s", resp.StatusCode, body)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 		promQLExperimentalFunctions     bool
 		promQLExtendedRangeSelectors    bool
 		promQLBinopFillModifiers        bool
+		rewriteHostHeader               string
 	)
 
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -100,6 +101,7 @@ func main() {
 		"API (like /api/v1/configuration) which isn't enforced by prom-label-proxy. NOTE: \"all\" matching paths like \"/\" or \"\" and regex are not allowed.")
 	flagset.BoolVar(&insecureSkipVerify, "insecure-skip-verify", false, "When specified, the proxy will bypass validation of the server's TLS/SSL certificate.")
 	flagset.BoolVar(&errorOnReplace, "error-on-replace", false, "When specified, the proxy will return HTTP status code 400 if the query already contains a label matcher that differs from the one the proxy would inject.")
+	flagset.StringVar(&rewriteHostHeader, "rewrite-host-header-to", "", "Rewrite the Host header to the supplied value when proxying requests to the upstream URL. Useful when the upstream is behind an ingress that routes based on the Host header.")
 	flagset.BoolVar(&regexMatch, "regex-match", false, "When specified, the tenant name is treated as a regular expression. In this case, only one tenant name should be provided.")
 	flagset.BoolVar(&headerUsesListSyntax, "header-uses-list-syntax", false, "When specified, the header line value will be parsed as a comma-separated list. This allows a single tenant header line to specify multiple tenant names.")
 	flagset.BoolVar(&rulesWithActiveAlerts, "rules-with-active-alerts", false, "When true, the proxy will return alerting rules with active alerts matching the tenant label even when the tenant label isn't present in the rule's labels.")
@@ -173,6 +175,10 @@ func main() {
 
 	if errorOnReplace {
 		opts = append(opts, injectproxy.WithErrorOnReplace())
+	}
+
+	if rewriteHostHeader != "" {
+		opts = append(opts, injectproxy.WithRewriteHostHeader(rewriteHostHeader))
 	}
 
 	if rulesWithActiveAlerts {


### PR DESCRIPTION
This adds a `--rewrite-host-header-to` CLI flag that allows overriding the Host header sent to the upstream URL when proxying requests.

When prom-label-proxy is deployed in front of an upstream Prometheus endpoint accessed via an ingress controller with host-based routing, the proxy forwards the original client's Host header. This causes the ingress to fail routing because it cannot match the expected hostname.

The implementation switches from NewSingleHostReverseProxy to a ReverseProxy with a custom Rewrite function, which provides explicit control over the outbound Host header. When the flag is not set, behavior is unchanged.

Fixes #135.